### PR TITLE
Update the #includes in shared_ptr_helper.hpp

### DIFF
--- a/include/boost/serialization/shared_ptr_helper.hpp
+++ b/include/boost/serialization/shared_ptr_helper.hpp
@@ -26,6 +26,8 @@
 #include <boost/type_traits/is_polymorphic.hpp>
 #include <boost/mpl/if.hpp>
 
+#include <boost/serialization/singleton.hpp>
+#include <boost/serialization/extended_type_info.hpp>
 #include <boost/serialization/type_info_implementation.hpp>
 #include <boost/serialization/throw_exception.hpp>
 #include <boost/archive/archive_exception.hpp>


### PR DESCRIPTION
We were getting errors like this during compilation:

```
In file included from /home/lofty/boost_1_56/include/boost/serialization/shared_ptr.hpp:28,
                 from linalg/src/LinearSystem.hpp:50,
                 from ./linalg/test/TestChebyshevIteration.hpp:40,
                 from linalg/build/debug_hostconfig,boost=1-56/TestChebyshevIterationRunner.cpp:21:
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp: In static member function static const boost::serialization::extended_type_info* boost::serialization::shared_ptr_helper<SPT>::non_polymorphic::get_object_type(U&)':
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:107: error: 'singleton' is not a member of 'boost::serialization'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:110: error: expected '(' before '>' token
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:110: error: '::get_const_instance' has not been declared
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp: In static member function 'static const boost::serialization::extended_type_info* boost::serialization::shared_ptr_helper<SPT>::polymorphic::get_object_type(U&)':
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:117: error: 'singleton' is not a member of 'boost::serialization'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:120: error: expected '(' before '>' token
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:120: error: '::get_const_instance' has not been declared
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp: In member function 'void boost::serialization::shared_ptr_helper<SPT>::reset(SPT<T>&, T*)':
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:152: error: invalid use of incomplete type 'const struct boost::serialization::extended_type_info'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:42: error: forward declaration of 'const struct boost::serialization::extended_type_info'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:167: error: invalid use of incomplete type 'const struct boost::serialization::extended_type_info'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:42: error: forward declaration of 'const struct boost::serialization::extended_type_info'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:168: error: invalid use of incomplete type 'const struct boost::serialization::extended_type_info'
/home/lofty/boost_1_56/include/boost/serialization/shared_ptr_helper.hpp:42: error: forward declaration of 'const struct boost::serialization::extended_type_info'
scons: *** [linalg/build/debug_hostconfig,boost=1-56/TestChebyshevIterationRunner.o] Error 1
```
