### PR TITLE
Initialize m_buffer_out

### DIFF
--- a/include/boost/archive/iterators/transform_width.hpp
+++ b/include/boost/archive/iterators/transform_width.hpp
@@ -113,6 +113,7 @@ public:
     transform_width(BOOST_PFTO_WRAPPER(T) start) : 
         super_t(Base(BOOST_MAKE_PFTO_WRAPPER(static_cast< T >(start)))),
         m_buffer_out_full(false),
+        m_buffer_out(),
         // To disable GCC warning, but not truly necessary 
 	    //(m_buffer_in will be initialized later before being 
 	    //used because m_remaining_bits == 0)
@@ -124,6 +125,7 @@ public:
     transform_width(const transform_width & rhs) : 
         super_t(rhs.base_reference()),
         m_buffer_out_full(rhs.m_buffer_out_full),
+        m_buffer_out(rhs.m_buffer_out),
         m_buffer_in(rhs.m_buffer_in),
         m_remaining_bits(rhs.m_remaining_bits),
         m_end_of_sequence(false)

--- a/include/boost/archive/iterators/transform_width.hpp
+++ b/include/boost/archive/iterators/transform_width.hpp
@@ -113,7 +113,7 @@ public:
     transform_width(BOOST_PFTO_WRAPPER(T) start) : 
         super_t(Base(BOOST_MAKE_PFTO_WRAPPER(static_cast< T >(start)))),
         m_buffer_out_full(false),
-        m_buffer_out(),
+        m_buffer_out(0),
         // To disable GCC warning, but not truly necessary 
 	    //(m_buffer_in will be initialized later before being 
 	    //used because m_remaining_bits == 0)

--- a/include/boost/archive/iterators/transform_width.hpp
+++ b/include/boost/archive/iterators/transform_width.hpp
@@ -113,7 +113,7 @@ public:
     transform_width(BOOST_PFTO_WRAPPER(T) start) : 
         super_t(Base(BOOST_MAKE_PFTO_WRAPPER(static_cast< T >(start)))),
         m_buffer_out_full(false),
-        m_buffer_out(0),
+        m_buffer_out(),
         // To disable GCC warning, but not truly necessary 
 	    //(m_buffer_in will be initialized later before being 
 	    //used because m_remaining_bits == 0)


### PR DESCRIPTION
The constructors for transform_width were not initializing m_buffer_out. This was uncovered by Coverity as issues CID60662 and CID54443.
