### PR TITLE
Fix warning in variant.hpp

### DIFF
--- a/include/boost/serialization/variant.hpp
+++ b/include/boost/serialization/variant.hpp
@@ -66,7 +66,6 @@ void save(
 ){
     int which = v.which();
     ar << BOOST_SERIALIZATION_NVP(which);
-    typedef typename  boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types types;
     variant_save_visitor<Archive> visitor(ar);
     v.apply_visitor(visitor);
 }


### PR DESCRIPTION
Fix for the following warning:

D:/Boost/boost/serialization/variant.hpp:69:75: warning: typedef 'types' locally defined but not used [-Wunused-local-typedefs]
     typedef typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types types;
