### PR TITLE
Fix DLL compilation on MSVC

### DIFF
--- a/include/boost/archive/basic_archive.hpp
+++ b/include/boost/archive/basic_archive.hpp
@@ -69,7 +69,7 @@ public:
     }   
 };
 
-library_version_type
+BOOST_ARCHIVE_DECL library_version_type
 BOOST_ARCHIVE_VERSION();
 
 class version_type {
@@ -242,7 +242,7 @@ enum archive_flags {
     flags_last = 8
 };
 
-const char *
+BOOST_ARCHIVE_DECL const char *
 BOOST_ARCHIVE_SIGNATURE();
 
 /* NOTE : Warning  : Warning : Warning : Warning : Warning

--- a/include/boost/archive/detail/archive_serializer_map.hpp
+++ b/include/boost/archive/detail/archive_serializer_map.hpp
@@ -38,9 +38,9 @@ class basic_serializer;
 template<class Archive>
 class BOOST_SYMBOL_VISIBLE archive_serializer_map {
 public:
-    static bool BOOST_ARCHIVE_OR_WARCHIVE_DECL insert(const basic_serializer * bs);
-    static void BOOST_ARCHIVE_OR_WARCHIVE_DECL erase(const basic_serializer * bs);
-    static const basic_serializer * BOOST_ARCHIVE_OR_WARCHIVE_DECL find(
+    static BOOST_ARCHIVE_OR_WARCHIVE_DECL bool insert(const basic_serializer * bs);
+    static BOOST_ARCHIVE_OR_WARCHIVE_DECL void erase(const basic_serializer * bs);
+    static BOOST_ARCHIVE_OR_WARCHIVE_DECL const basic_serializer * find(
         const boost::serialization::extended_type_info & type_
     );
 };

--- a/include/boost/archive/detail/basic_iarchive.hpp
+++ b/include/boost/archive/detail/basic_iarchive.hpp
@@ -56,23 +56,23 @@ class BOOST_SYMBOL_VISIBLE basic_iarchive :
     virtual void vload(class_name_type &t) = 0;
     virtual void vload(tracking_type &t) = 0;
 protected:
-    basic_iarchive(unsigned int flags);
+    BOOST_ARCHIVE_DECL basic_iarchive(unsigned int flags);
 public:
     // account for bogus gcc warning
     #if defined(__GNUC__)
     virtual
     #endif
-    ~basic_iarchive();
+    BOOST_ARCHIVE_DECL ~basic_iarchive();
     // note: NOT part of the public API.
-    void next_object_pointer(void *t);
-    void register_basic_serializer(
+    BOOST_ARCHIVE_DECL void next_object_pointer(void *t);
+    BOOST_ARCHIVE_DECL void register_basic_serializer(
         const basic_iserializer & bis
     );
-    void load_object(
+    BOOST_ARCHIVE_DECL void load_object(
         void *t, 
         const basic_iserializer & bis
     );
-    const basic_pointer_iserializer * 
+    BOOST_ARCHIVE_DECL const basic_pointer_iserializer * 
     load_pointer(
         void * & t, 
         const basic_pointer_iserializer * bpis_ptr,
@@ -82,15 +82,15 @@ public:
 
     );
     // real public API starts here
-    void 
+    BOOST_ARCHIVE_DECL void 
     set_library_version(library_version_type archive_library_version);
-    library_version_type 
+    BOOST_ARCHIVE_DECL library_version_type 
     get_library_version() const;
-    unsigned int
+    BOOST_ARCHIVE_DECL unsigned int
     get_flags() const;
-    void 
+    BOOST_ARCHIVE_DECL void 
     reset_object_address(const void * new_address, const void * old_address);
-    void 
+    BOOST_ARCHIVE_DECL void 
     delete_created_pointers();
 };
 

--- a/include/boost/archive/detail/basic_iserializer.hpp
+++ b/include/boost/archive/detail/basic_iserializer.hpp
@@ -48,14 +48,14 @@ class BOOST_SYMBOL_VISIBLE basic_iserializer :
 private:
     basic_pointer_iserializer *m_bpis;
 protected:
-    explicit basic_iserializer(
+    explicit BOOST_ARCHIVE_DECL basic_iserializer(
         const boost::serialization::extended_type_info & type
     );
     // account for bogus gcc warning
     #if defined(__GNUC__)
     virtual
     #endif
-    ~basic_iserializer();
+    BOOST_ARCHIVE_DECL ~basic_iserializer();
 public:
     bool serialized_as_pointer() const {
         return m_bpis != NULL;

--- a/include/boost/archive/detail/basic_oarchive.hpp
+++ b/include/boost/archive/detail/basic_oarchive.hpp
@@ -59,22 +59,22 @@ class BOOST_SYMBOL_VISIBLE basic_oarchive :
     virtual void vsave(const class_name_type & t) = 0;
     virtual void vsave(const tracking_type t) = 0;
 protected:
-    basic_oarchive(unsigned int flags = 0);
+    BOOST_ARCHIVE_DECL basic_oarchive(unsigned int flags = 0);
     // account for bogus gcc warning
     #if defined(__GNUC__)
     virtual
     #endif
-    ~basic_oarchive();
+    BOOST_ARCHIVE_DECL ~basic_oarchive();
 public:
     // note: NOT part of the public interface
-    void register_basic_serializer(
+    BOOST_ARCHIVE_DECL void register_basic_serializer(
         const basic_oserializer & bos
     );
-    void save_object(
+    BOOST_ARCHIVE_DECL void save_object(
         const void *x, 
         const basic_oserializer & bos
     );
-    void save_pointer(
+    BOOST_ARCHIVE_DECL void save_pointer(
         const void * t, 
         const basic_pointer_oserializer * bpos_ptr
     );
@@ -82,9 +82,9 @@ public:
         vsave(NULL_POINTER_TAG);
     }
     // real public interface starts here
-    void end_preamble(); // default implementation does nothing
-    library_version_type get_library_version() const;
-    unsigned int get_flags() const;
+    BOOST_ARCHIVE_DECL void end_preamble(); // default implementation does nothing
+    BOOST_ARCHIVE_DECL library_version_type get_library_version() const;
+    BOOST_ARCHIVE_DECL unsigned int get_flags() const;
 };
 
 } // namespace detail

--- a/include/boost/archive/detail/basic_oserializer.hpp
+++ b/include/boost/archive/detail/basic_oserializer.hpp
@@ -49,14 +49,14 @@ class BOOST_SYMBOL_VISIBLE basic_oserializer :
 private:
     basic_pointer_oserializer *m_bpos;
 protected:
-    explicit basic_oserializer(
+    explicit BOOST_ARCHIVE_DECL basic_oserializer(
         const boost::serialization::extended_type_info & type_
     );
     // account for bogus gcc warning
     #if defined(__GNUC__)
     virtual
     #endif
-    ~basic_oserializer();
+    BOOST_ARCHIVE_DECL ~basic_oserializer();
 public:
     bool serialized_as_pointer() const {
         return m_bpos != NULL;

--- a/include/boost/archive/detail/basic_pointer_iserializer.hpp
+++ b/include/boost/archive/detail/basic_pointer_iserializer.hpp
@@ -43,14 +43,14 @@ class basic_iserializer;
 class BOOST_SYMBOL_VISIBLE basic_pointer_iserializer
     : public basic_serializer {
 protected:
-    explicit basic_pointer_iserializer(
+    explicit BOOST_ARCHIVE_DECL basic_pointer_iserializer(
         const boost::serialization::extended_type_info & type_
     );
     // account for bogus gcc warning
     #if defined(__GNUC__)
     virtual
     #endif
-    ~basic_pointer_iserializer();
+    BOOST_ARCHIVE_DECL ~basic_pointer_iserializer();
 public:
     virtual void * heap_allocation() const = 0;
     virtual const basic_iserializer & get_basic_serializer() const = 0;

--- a/include/boost/archive/detail/basic_pointer_oserializer.hpp
+++ b/include/boost/archive/detail/basic_pointer_oserializer.hpp
@@ -43,7 +43,7 @@ class BOOST_SYMBOL_VISIBLE basic_pointer_oserializer :
     public basic_serializer
 {
 protected:
-    explicit basic_pointer_oserializer(
+    explicit BOOST_ARCHIVE_DECL basic_pointer_oserializer(
         const boost::serialization::extended_type_info & type_
     );
 public:
@@ -51,7 +51,7 @@ public:
     #if defined(__GNUC__)
     virtual
     #endif
-    ~basic_pointer_oserializer();
+    BOOST_ARCHIVE_DECL ~basic_pointer_oserializer();
     virtual const basic_oserializer & get_basic_serializer() const = 0;
     virtual void save_object_ptr(
         basic_oarchive & ar,

--- a/include/boost/archive/detail/basic_serializer_map.hpp
+++ b/include/boost/archive/detail/basic_serializer_map.hpp
@@ -50,9 +50,9 @@ basic_serializer_map : public
     > map_type;
     map_type m_map;
 public:
-    bool insert(const basic_serializer * bs);
-    void erase(const basic_serializer * bs);
-    const basic_serializer * find(
+    BOOST_ARCHIVE_DECL bool insert(const basic_serializer * bs);
+    BOOST_ARCHIVE_DECL void erase(const basic_serializer * bs);
+    BOOST_ARCHIVE_DECL const basic_serializer * find(
         const boost::serialization::extended_type_info & type_
     ) const;
 private:

--- a/include/boost/archive/xml_archive_exception.hpp
+++ b/include/boost/archive/xml_archive_exception.hpp
@@ -40,7 +40,7 @@ public:
         xml_archive_tag_mismatch,
         xml_archive_tag_name_error
     } exception_code;
-    xml_archive_exception(
+    BOOST_ARCHIVE_DECL xml_archive_exception(
         exception_code c, 
         const char * e1 = NULL,
         const char * e2 = NULL

--- a/include/boost/serialization/extended_type_info.hpp
+++ b/include/boost/serialization/extended_type_info.hpp
@@ -56,12 +56,12 @@ private:
     const char * m_key;
 
 protected:
-    void key_unregister() const;
-    void key_register() const;
+    BOOST_SERIALIZATION_DECL void key_unregister() const;
+    BOOST_SERIALIZATION_DECL void key_register() const;
     // this class can't be used as is. It's just the 
     // common functionality for all type_info replacement
     // systems.  Hence, make these protected
-    extended_type_info(
+    BOOST_SERIALIZATION_DECL extended_type_info(
         const unsigned int type_info_key,
         const char * key
     );
@@ -69,20 +69,20 @@ protected:
     #if defined(__GNUC__)
     virtual
     #endif
-    ~extended_type_info();
+    BOOST_SERIALIZATION_DECL ~extended_type_info();
 public:
     const char * get_key() const {
         return m_key;
     }
     virtual const char * get_debug_info() const = 0;
-    bool operator<(const extended_type_info &rhs) const;
-    bool operator==(const extended_type_info &rhs) const;
+    BOOST_SERIALIZATION_DECL bool operator<(const extended_type_info &rhs) const;
+    BOOST_SERIALIZATION_DECL bool operator==(const extended_type_info &rhs) const;
     bool operator!=(const extended_type_info &rhs) const {
         return !(operator==(rhs));
     }
     // note explicit "export" of static function to work around
     // gcc 4.5 mingw error
-    static const extended_type_info *
+    static BOOST_SERIALIZATION_DECL const extended_type_info *
     find(const char *key);
     // for plugins
     virtual void * construct(unsigned int /*count*/ = 0, ...) const = 0;

--- a/include/boost/serialization/extended_type_info_no_rtti.hpp
+++ b/include/boost/serialization/extended_type_info_no_rtti.hpp
@@ -56,12 +56,12 @@ class BOOST_SYMBOL_VISIBLE extended_type_info_no_rtti_0 :
     public extended_type_info
 {
 protected:
-    extended_type_info_no_rtti_0(const char * key);
-    ~extended_type_info_no_rtti_0();
+    BOOST_SERIALIZATION_DECL extended_type_info_no_rtti_0(const char * key);
+    BOOST_SERIALIZATION_DECL ~extended_type_info_no_rtti_0();
 public:
-    virtual bool
+    virtual BOOST_SERIALIZATION_DECL bool
     is_less_than(const boost::serialization::extended_type_info &rhs) const ;
-    virtual bool
+    virtual BOOST_SERIALIZATION_DECL bool
     is_equal(const boost::serialization::extended_type_info &rhs) const ;
 };
 

--- a/include/boost/serialization/extended_type_info_typeid.hpp
+++ b/include/boost/serialization/extended_type_info_typeid.hpp
@@ -59,16 +59,16 @@ class BOOST_SYMBOL_VISIBLE extended_type_info_typeid_0 :
     }
 protected:
     const std::type_info * m_ti;
-    extended_type_info_typeid_0(const char * key);
-    ~extended_type_info_typeid_0();
-    void type_register(const std::type_info & ti);
-    void type_unregister();
-    const extended_type_info *
+    BOOST_SERIALIZATION_DECL extended_type_info_typeid_0(const char * key);
+    BOOST_SERIALIZATION_DECL ~extended_type_info_typeid_0();
+    BOOST_SERIALIZATION_DECL void type_register(const std::type_info & ti);
+    BOOST_SERIALIZATION_DECL void type_unregister();
+    BOOST_SERIALIZATION_DECL const extended_type_info *
     get_extended_type_info(const std::type_info & ti) const;
 public:
-    virtual bool
+    virtual BOOST_SERIALIZATION_DECL bool
     is_less_than(const extended_type_info &rhs) const;
-    virtual bool
+    virtual BOOST_SERIALIZATION_DECL bool
     is_equal(const extended_type_info &rhs) const;
     const std::type_info & get_typeid() const {
         return *m_ti;

--- a/include/boost/serialization/void_cast.hpp
+++ b/include/boost/serialization/void_cast.hpp
@@ -107,8 +107,8 @@ class BOOST_SYMBOL_VISIBLE void_caster :
         void const * const
     );
 protected:
-    void recursive_register(bool includes_virtual_base = false) const;
-    void recursive_unregister() const;
+    BOOST_SERIALIZATION_DECL void recursive_register(bool includes_virtual_base = false) const;
+    BOOST_SERIALIZATION_DECL void recursive_unregister() const;
     virtual bool has_virtual_base() const = 0;
 public:
     // Data members


### PR DESCRIPTION
Please find a patch that makes all regression tests pass on MSVC14 here:

Marcel Raad