### PR TITLE
Typo in comment

### DIFF
--- a/include/boost/archive/detail/iserializer.hpp
+++ b/include/boost/archive/detail/iserializer.hpp
@@ -597,7 +597,7 @@ template<class Archive, class T>
 inline void load(Archive & ar, T &t){
     // if this assertion trips. It means we're trying to load a
     // const object with a compiler that doesn't have correct
-    // funtion template ordering.  On other compilers, this is
+    // function template ordering.  On other compilers, this is
     // handled below.
     detail::check_const_loading< T >();
     typedef


### PR DESCRIPTION
Funtion -> function. 
I know it's not critical.
