### PR TITLE
Removed unused parameter, caught by clang warnings.

### DIFF
--- a/include/boost/serialization/smart_cast.hpp
+++ b/include/boost/serialization/smart_cast.hpp
@@ -223,7 +223,7 @@ namespace smart_cast_impl {
         // cast on a system which doesn't support partial template 
         // specialization
         template<class U>
-        static T cast(U u){
+        static T cast(U){
             BOOST_STATIC_ASSERT(sizeof(T)==0);
             return * static_cast<T *>(NULL);
         }


### PR DESCRIPTION
Removes an unused parameter that clang 3.6 generates a warning on.