### PR TITLE
classes with virtual function must have virtual destructors.

### DIFF
--- a/include/boost/archive/detail/basic_iarchive.hpp
+++ b/include/boost/archive/detail/basic_iarchive.hpp
@@ -65,11 +65,7 @@ protected:
 public:
     // some msvc versions require that the following function be public
     // otherwise it should really protected.
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_ARCHIVE_DECL ~basic_iarchive();
+    virtual BOOST_ARCHIVE_DECL ~basic_iarchive();
     // note: NOT part of the public API.
     BOOST_ARCHIVE_DECL void next_object_pointer(void *t);
     BOOST_ARCHIVE_DECL void register_basic_serializer(

--- a/include/boost/archive/detail/basic_iserializer.hpp
+++ b/include/boost/archive/detail/basic_iserializer.hpp
@@ -51,11 +51,7 @@ protected:
     explicit BOOST_ARCHIVE_DECL basic_iserializer(
         const boost::serialization::extended_type_info & type
     );
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_ARCHIVE_DECL ~basic_iserializer();
+    virtual BOOST_ARCHIVE_DECL ~basic_iserializer();
 public:
     bool serialized_as_pointer() const {
         return m_bpis != NULL;

--- a/include/boost/archive/detail/basic_oarchive.hpp
+++ b/include/boost/archive/detail/basic_oarchive.hpp
@@ -64,11 +64,7 @@ protected:
     get_helper_collection(){
         return *this;
     }
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_ARCHIVE_DECL ~basic_oarchive();
+    virtual BOOST_ARCHIVE_DECL ~basic_oarchive();
 public:
     // note: NOT part of the public interface
     BOOST_ARCHIVE_DECL void register_basic_serializer(

--- a/include/boost/archive/detail/basic_oserializer.hpp
+++ b/include/boost/archive/detail/basic_oserializer.hpp
@@ -52,11 +52,7 @@ protected:
     explicit BOOST_ARCHIVE_DECL basic_oserializer(
         const boost::serialization::extended_type_info & type_
     );
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_ARCHIVE_DECL ~basic_oserializer();
+    virtual BOOST_ARCHIVE_DECL ~basic_oserializer();
 public:
     bool serialized_as_pointer() const {
         return m_bpos != NULL;

--- a/include/boost/archive/detail/basic_pointer_iserializer.hpp
+++ b/include/boost/archive/detail/basic_pointer_iserializer.hpp
@@ -46,11 +46,7 @@ protected:
     explicit BOOST_ARCHIVE_DECL basic_pointer_iserializer(
         const boost::serialization::extended_type_info & type_
     );
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_ARCHIVE_DECL ~basic_pointer_iserializer();
+    virtual BOOST_ARCHIVE_DECL ~basic_pointer_iserializer();
 public:
     virtual void * heap_allocation() const = 0;
     virtual const basic_iserializer & get_basic_serializer() const = 0;

--- a/include/boost/archive/detail/basic_pointer_oserializer.hpp
+++ b/include/boost/archive/detail/basic_pointer_oserializer.hpp
@@ -47,11 +47,7 @@ protected:
         const boost::serialization::extended_type_info & type_
     );
 public:
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_ARCHIVE_DECL ~basic_pointer_oserializer();
+    virtual BOOST_ARCHIVE_DECL ~basic_pointer_oserializer();
     virtual const basic_oserializer & get_basic_serializer() const = 0;
     virtual void save_object_ptr(
         basic_oarchive & ar,

--- a/include/boost/serialization/extended_type_info.hpp
+++ b/include/boost/serialization/extended_type_info.hpp
@@ -65,11 +65,7 @@ protected:
         const unsigned int type_info_key,
         const char * key
     );
-    // account for bogus gcc warning
-    #if defined(__GNUC__)
-    virtual
-    #endif
-    BOOST_SERIALIZATION_DECL ~extended_type_info();
+    virtual BOOST_SERIALIZATION_DECL ~extended_type_info();
 public:
     const char * get_key() const {
         return m_key;


### PR DESCRIPTION
The warning is not "bogus" and not only gcc warns.
clang will warn too, but defines __GNUC__ for gcc compatibility.
msvc issues "warning C4265: 'boost::serialization::<foo>' :
class has virtual functions, but destructor is not virtual"
The msvc warning could be suppressed, but it is much cleaner to simply
make the destructors virtual as they are with gcc and clang.