### PR TITLE
Fix template arguments (Mapped type was missing) and add support for the boost unordered types

### DIFF
--- a/include/boost/archive/detail/interface_oarchive.hpp
+++ b/include/boost/archive/detail/interface_oarchive.hpp
@@ -9,7 +9,7 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // interface_oarchive.hpp
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -32,7 +32,7 @@ namespace detail {
 class BOOST_ARCHIVE_OR_WARCHIVE_DECL basic_pointer_oserializer;
 
 template<class Archive>
-class interface_oarchive 
+class interface_oarchive
 {
 protected:
     interface_oarchive(){};
@@ -48,7 +48,7 @@ public:
     }
 
     template<class T>
-    const basic_pointer_oserializer * 
+    const basic_pointer_oserializer *
     register_type(const T * = NULL){
         const basic_pointer_oserializer & bpos =
             boost::serialization::singleton<
@@ -57,7 +57,7 @@ public:
         this->This()->register_basic_serializer(bpos.get_basic_serializer());
         return & bpos;
     }
-    
+
     template<class Helper>
     Helper &
     get_helper(void * const id = 0){
@@ -70,12 +70,12 @@ public:
         this->This()->save_override(t);
         return * this->This();
     }
-    
-    // the & operator 
+
+    // the & operator
     template<class T>
     Archive & operator&(const T & t){
         return * this ->This() << t;
-    };
+    }
 };
 
 } // namespace detail

--- a/include/boost/serialization/unordered_map.hpp
+++ b/include/boost/serialization/unordered_map.hpp
@@ -10,8 +10,9 @@
 // serialization/unordered_map.hpp:
 // serialization for stl unordered_map templates
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
+// (C) Copyright 2015 Christoph Weiss
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -21,13 +22,14 @@
 #include <boost/config.hpp>
 
 #include <unordered_map>
+#include <boost/unordered_map.hpp>
 
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/unordered_collections_save_imp.hpp>
 #include <boost/serialization/unordered_collections_load_imp.hpp>
 #include <boost/serialization/split_free.hpp>
 
-namespace boost { 
+namespace boost {
 namespace serialization {
 
 namespace stl {
@@ -37,19 +39,19 @@ template<class Archive, class Container>
 struct archive_input_unordered_map
 {
     inline void operator()(
-        Archive &ar, 
-        Container &s, 
+        Archive &ar,
+        Container &s,
         const unsigned int v
     ){
         typedef typename Container::value_type type;
         detail::stack_construct<Archive, type> t(ar, v);
         // borland fails silently w/o full namespace
         ar >> boost::serialization::make_nvp("item", t.reference());
-        std::pair<typename Container::const_iterator, bool> result = 
+        std::pair<typename Container::const_iterator, bool> result =
             s.insert(t.reference());
         // note: the following presumes that the map::value_type was NOT tracked
         // in the archive.  This is the usual case, but here there is no way
-        // to determine that.  
+        // to determine that.
         if(result.second){
             ar.reset_object_address(
                 & (result.first->second),
@@ -64,19 +66,19 @@ template<class Archive, class Container>
 struct archive_input_unordered_multimap
 {
     inline void operator()(
-        Archive &ar, 
-        Container &s, 
+        Archive &ar,
+        Container &s,
         const unsigned int v
     ){
         typedef typename Container::value_type type;
         detail::stack_construct<Archive, type> t(ar, v);
         // borland fails silently w/o full namespace
         ar >> boost::serialization::make_nvp("item", t.reference());
-        typename Container::const_iterator result 
+        typename Container::const_iterator result
             = s.insert(t.reference());
         // note: the following presumes that the map::value_type was NOT tracked
         // in the archive.  This is the usual case, but here there is no way
-        // to determine that.  
+        // to determine that.
         ar.reset_object_address(
             & result->second,
             & t.reference()
@@ -87,50 +89,104 @@ struct archive_input_unordered_multimap
 } // stl
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void save(
     Archive & ar,
     const std::unordered_map<
-        Key, HashFcn, EqualKey, Allocator
+        Key, Mapped, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
-        Archive, 
+        Archive,
         std::unordered_map<
-            Key, HashFcn, EqualKey, Allocator
+            Key, Mapped, HashFcn, EqualKey, Allocator
         >
     >(ar, t);
 }
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void save(
+    Archive & ar,
+    const boost::unordered_map<
+        Key, Mapped, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::save_unordered_collection<
+        Archive,
+        boost::unordered_map<
+            Key, Mapped, HashFcn, EqualKey, Allocator
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void load(
     Archive & ar,
     std::unordered_map<
-        Key, HashFcn, EqualKey, Allocator
+        Key, Mapped, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::load_unordered_collection<
         Archive,
         std::unordered_map<
-            Key, HashFcn, EqualKey, Allocator
+            Key, Mapped, HashFcn, EqualKey, Allocator
         >,
         boost::serialization::stl::archive_input_unordered_map<
-            Archive, 
+            Archive,
             std::unordered_map<
-                Key, HashFcn, EqualKey, Allocator
+                Key, Mapped, HashFcn, EqualKey, Allocator
+            >
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void load(
+    Archive & ar,
+    boost::unordered_map<
+        Key, Mapped, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::load_unordered_collection<
+        Archive,
+        boost::unordered_map<
+            Key, Mapped, HashFcn, EqualKey, Allocator
+        >,
+        boost::serialization::stl::archive_input_unordered_map<
+            Archive,
+            boost::unordered_map<
+                Key, Mapped, HashFcn, EqualKey, Allocator
             >
         >
     >(ar, t);
@@ -139,16 +195,35 @@ inline void load(
 // split non-intrusive serialization function member into separate
 // non intrusive save/load member functions
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void serialize(
     Archive & ar,
     std::unordered_map<
-        Key, HashFcn, EqualKey, Allocator
+        Key, Mapped, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+template<
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void serialize(
+    Archive & ar,
+    boost::unordered_map<
+        Key, Mapped, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int file_version
 ){
@@ -157,50 +232,104 @@ inline void serialize(
 
 // unordered_multimap
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void save(
     Archive & ar,
     const std::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, Mapped, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
-        Archive, 
+        Archive,
         std::unordered_multimap<
-            Key, HashFcn, EqualKey, Allocator
+            Key, Mapped, HashFcn, EqualKey, Allocator
         >
     >(ar, t);
 }
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void save(
+    Archive & ar,
+    const boost::unordered_multimap<
+        Key, Mapped, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::save_unordered_collection<
+        Archive,
+        boost::unordered_multimap<
+            Key, Mapped, HashFcn, EqualKey, Allocator
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void load(
     Archive & ar,
     std::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, Mapped, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::load_unordered_collection<
         Archive,
         std::unordered_multimap<
-            Key, HashFcn, EqualKey, Allocator
+            Key, Mapped, HashFcn, EqualKey, Allocator
         >,
         boost::serialization::stl::archive_input_unordered_multimap<
-            Archive, 
+            Archive,
             std::unordered_multimap<
-                Key, HashFcn, EqualKey, Allocator
+                Key, Mapped, HashFcn, EqualKey, Allocator
+            >
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void load(
+    Archive & ar,
+    boost::unordered_multimap<
+        Key, Mapped, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::load_unordered_collection<
+        Archive,
+        boost::unordered_multimap<
+            Key, Mapped, HashFcn, EqualKey, Allocator
+        >,
+        boost::serialization::stl::archive_input_unordered_multimap<
+            Archive,
+            boost::unordered_multimap<
+                Key, Mapped, HashFcn, EqualKey, Allocator
             >
         >
     >(ar, t);
@@ -209,16 +338,35 @@ inline void load(
 // split non-intrusive serialization function member into separate
 // non intrusive save/load member functions
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void serialize(
     Archive & ar,
     std::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, Mapped, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+template<
+    class Archive,
+    class Key,
+    class Mapped,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void serialize(
+    Archive & ar,
+    boost::unordered_multimap<
+        Key, Mapped, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int file_version
 ){

--- a/include/boost/serialization/unordered_set.hpp
+++ b/include/boost/serialization/unordered_set.hpp
@@ -9,7 +9,7 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // unordered_set.hpp: serialization for stl unordered_set templates
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
@@ -20,12 +20,13 @@
 #include <boost/config.hpp>
 
 #include <unordered_set>
+#include <boost/unordered_set.hpp>
 
 #include <boost/serialization/unordered_collections_save_imp.hpp>
 #include <boost/serialization/unordered_collections_load_imp.hpp>
 #include <boost/serialization/split_free.hpp>
 
-namespace boost { 
+namespace boost {
 namespace serialization {
 
 namespace stl {
@@ -35,15 +36,15 @@ template<class Archive, class Container>
 struct archive_input_unordered_set
 {
     inline void operator()(
-        Archive &ar, 
-        Container &s, 
+        Archive &ar,
+        Container &s,
         const unsigned int v
     ){
         typedef typename Container::value_type type;
         detail::stack_construct<Archive, type> t(ar, v);
         // borland fails silently w/o full namespace
         ar >> boost::serialization::make_nvp("item", t.reference());
-        std::pair<typename Container::const_iterator, bool> result = 
+        std::pair<typename Container::const_iterator, bool> result =
             s.insert(t.reference());
         if(result.second)
             ar.reset_object_address(& (* result.first), & t.reference());
@@ -55,15 +56,15 @@ template<class Archive, class Container>
 struct archive_input_unordered_multiset
 {
     inline void operator()(
-        Archive &ar, 
-        Container &s, 
+        Archive &ar,
+        Container &s,
         const unsigned int v
     ){
         typedef typename Container::value_type type;
         detail::stack_construct<Archive, type> t(ar, v);
         // borland fails silently w/o full namespace
         ar >> boost::serialization::make_nvp("item", t.reference());
-        typename Container::const_iterator result 
+        typename Container::const_iterator result
             = s.insert(t.reference());
         ar.reset_object_address(& (* result), & t.reference());
     }
@@ -72,9 +73,9 @@ struct archive_input_unordered_multiset
 } // stl
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -86,17 +87,39 @@ inline void save(
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
-        Archive, 
+        Archive,
         std::unordered_set<
             Key, HashFcn, EqualKey, Allocator
-        > 
+        >
     >(ar, t);
 }
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void save(
+    Archive & ar,
+    const boost::unordered_set<
+        Key, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::save_unordered_collection<
+        Archive,
+        boost::unordered_set<
+            Key, HashFcn, EqualKey, Allocator
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -113,8 +136,36 @@ inline void load(
             Key, HashFcn, EqualKey, Allocator
         >,
         boost::serialization::stl::archive_input_unordered_set<
-            Archive, 
+            Archive,
             std::unordered_set<
+                Key, HashFcn, EqualKey, Allocator
+            >
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void load(
+    Archive & ar,
+    boost::unordered_set<
+        Key, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::load_unordered_collection<
+        Archive,
+        boost::unordered_set<
+            Key, HashFcn, EqualKey, Allocator
+        >,
+        boost::serialization::stl::archive_input_unordered_set<
+            Archive,
+            boost::unordered_set<
                 Key, HashFcn, EqualKey, Allocator
             >
         >
@@ -124,9 +175,9 @@ inline void load(
 // split non-intrusive serialization function member into separate
 // non intrusive save/load member functions
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -140,11 +191,28 @@ inline void serialize(
     boost::serialization::split_free(ar, t, file_version);
 }
 
+template<
+    class Archive,
+    class Key,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void serialize(
+    Archive & ar,
+    boost::unordered_set<
+        Key, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
 // unordered_multiset
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -156,17 +224,39 @@ inline void save(
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
-        Archive, 
+        Archive,
         std::unordered_multiset<
             Key, HashFcn, EqualKey, Allocator
-        > 
+        >
     >(ar, t);
 }
 
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void save(
+    Archive & ar,
+    const boost::unordered_multiset<
+        Key, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::save_unordered_collection<
+        Archive,
+        boost::unordered_multiset<
+            Key, HashFcn, EqualKey, Allocator
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
@@ -186,7 +276,35 @@ inline void load(
             Archive,
             std::unordered_multiset<
                 Key, HashFcn, EqualKey, Allocator
-            > 
+            >
+        >
+    >(ar, t);
+}
+
+template<
+    class Archive,
+    class Key,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void load(
+    Archive & ar,
+    boost::unordered_multiset<
+        Key, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int /*file_version*/
+){
+    boost::serialization::stl::load_unordered_collection<
+        Archive,
+        boost::unordered_multiset<
+            Key, HashFcn, EqualKey, Allocator
+        >,
+        boost::serialization::stl::archive_input_unordered_multiset<
+            Archive,
+            boost::unordered_multiset<
+                Key, HashFcn, EqualKey, Allocator
+            >
         >
     >(ar, t);
 }
@@ -194,15 +312,32 @@ inline void load(
 // split non-intrusive serialization function member into separate
 // non intrusive save/load member functions
 template<
-    class Archive, 
-    class Key, 
-    class HashFcn, 
+    class Archive,
+    class Key,
+    class HashFcn,
     class EqualKey,
     class Allocator
 >
 inline void serialize(
     Archive & ar,
     std::unordered_multiset<
+        Key, HashFcn, EqualKey, Allocator
+    > &t,
+    const unsigned int file_version
+){
+    boost::serialization::split_free(ar, t, file_version);
+}
+
+template<
+    class Archive,
+    class Key,
+    class HashFcn,
+    class EqualKey,
+    class Allocator
+>
+inline void serialize(
+    Archive & ar,
+    boost::unordered_multiset<
         Key, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int file_version

--- a/test/test_map.cpp
+++ b/test/test_map.cpp
@@ -1,8 +1,9 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // test_map.cpp
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
+// (C) Copyright 2015 Christoph Weiss
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -19,8 +20,8 @@
 
 #include <cstdio>
 #if defined(BOOST_NO_STDC_NAMESPACE)
-namespace std{ 
-    using ::rand; 
+namespace std{
+    using ::rand;
     using ::size_t;
 }
 #endif
@@ -40,7 +41,7 @@ struct random_key {
     friend class boost::serialization::access;
     template<class Archive>
     void serialize(
-        Archive & ar, 
+        Archive & ar,
         const unsigned int /* file_version */
     ){
         ar & boost::serialization::make_nvp("random_key", m_i);
@@ -56,7 +57,7 @@ struct random_key {
     operator std::size_t () const {    // required by hash_map
         return m_i;
     }
-};  
+};
 
 void
 test_map(){
@@ -68,7 +69,7 @@ test_map(){
     std::map<random_key, A> amap;
     amap.insert(std::make_pair(random_key(), A()));
     amap.insert(std::make_pair(random_key(), A()));
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("amap", amap);
@@ -124,7 +125,7 @@ test_multimap(){
     std::multimap<random_key, A> amultimap;
     amultimap.insert(std::make_pair(random_key(), A()));
     amultimap.insert(std::make_pair(random_key(), A()));
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("amultimap", amultimap);
@@ -149,7 +150,7 @@ namespace BOOST_STD_EXTENSION_NAMESPACE {
             return static_cast<std::size_t>(r);
         }
     };
-} // namespace BOOST_STD_EXTENSION_NAMESPACE 
+} // namespace BOOST_STD_EXTENSION_NAMESPACE
 
 void
 test_hash_map(){
@@ -161,7 +162,7 @@ test_hash_map(){
     BOOST_STD_EXTENSION_NAMESPACE::hash_map<random_key, A> ahash_map;
     ahash_map.insert(std::make_pair(random_key(), A()));
     ahash_map.insert(std::make_pair(random_key(), A()));
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("ahashmap",ahash_map);
@@ -192,7 +193,7 @@ test_hash_multimap(){
     BOOST_STD_EXTENSION_NAMESPACE::hash_multimap<random_key, A> ahash_multimap;
     ahash_multimap.insert(std::make_pair(random_key(), A()));
     ahash_multimap.insert(std::make_pair(random_key(), A()));
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("ahash_multimap", ahash_multimap);
@@ -215,10 +216,83 @@ test_hash_multimap(){
 }
 #endif
 
-#ifndef BOOST_NO_CXX11_HDR_UNORDERED_MAP
-
 #include <boost/serialization/unordered_map.hpp>
 #include <functional> // requires changeset [69520]; Ticket #5254
+
+namespace boost {
+    template<>
+    struct hash<random_key>{
+        std::size_t operator()(const random_key& r) const {
+            return static_cast<std::size_t>(r);
+        }
+    };
+} // namespace boost
+
+void
+test_boost_unordered_map(){
+    const char * testfile = boost::archive::tmpnam(NULL);
+    BOOST_REQUIRE(NULL != testfile);
+
+    BOOST_CHECKPOINT("unordered_map");
+    // test unordered_map of objects
+    boost::unordered_map<random_key, A> anunordered_map;
+    anunordered_map.insert(std::make_pair(random_key(), A()));
+    anunordered_map.insert(std::make_pair(random_key(), A()));
+    {
+        test_ostream os(testfile, TEST_STREAM_FLAGS);
+        test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
+        oa << boost::serialization::make_nvp("anunorderedmap",anunordered_map);
+    }
+    boost::unordered_map<random_key, A> anunordered_map1;
+    {
+        test_istream is(testfile, TEST_STREAM_FLAGS);
+        test_iarchive ia(is, TEST_ARCHIVE_FLAGS);
+        ia >> boost::serialization::make_nvp("anunorderedmap",anunordered_map1);
+    }
+
+    std::vector< std::pair<random_key, A> > tvec, tvec1;
+    std::copy(anunordered_map.begin(), anunordered_map.end(), std::back_inserter(tvec));
+    std::sort(tvec.begin(), tvec.end());
+    std::copy(anunordered_map1.begin(), anunordered_map1.end(), std::back_inserter(tvec1));
+    std::sort(tvec1.begin(), tvec1.end());
+    BOOST_CHECK(tvec == tvec1);
+
+    std::remove(testfile);
+}
+
+void
+test_boost_unordered_multimap(){
+    const char * testfile = boost::archive::tmpnam(NULL);
+    BOOST_REQUIRE(NULL != testfile);
+
+    BOOST_CHECKPOINT("unordered_multimap");
+    boost::unordered_multimap<random_key, A> anunordered_multimap;
+    anunordered_multimap.insert(std::make_pair(random_key(), A()));
+    anunordered_multimap.insert(std::make_pair(random_key(), A()));
+    {
+        test_ostream os(testfile, TEST_STREAM_FLAGS);
+        test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
+        oa << boost::serialization::make_nvp("anunordered_multimap", anunordered_multimap);
+    }
+    boost::unordered_multimap<random_key, A> anunordered_multimap1;
+    {
+        test_istream is(testfile, TEST_STREAM_FLAGS);
+        test_iarchive ia(is, TEST_ARCHIVE_FLAGS);
+        ia >> boost::serialization::make_nvp("anunordered_multimap", anunordered_multimap1);
+    }
+    std::vector< std::pair<random_key, A> > tvec, tvec1;
+    tvec.clear();
+    tvec1.clear();
+    std::copy(anunordered_multimap.begin(), anunordered_multimap.end(), std::back_inserter(tvec));
+    std::sort(tvec.begin(), tvec.end());
+    std::copy(anunordered_multimap1.begin(), anunordered_multimap1.end(), std::back_inserter(tvec1));
+    std::sort(tvec1.begin(), tvec1.end());
+    BOOST_CHECK(tvec == tvec1);
+    std::remove(testfile);
+}
+
+
+#ifndef BOOST_NO_CXX11_HDR_UNORDERED_MAP
 
 namespace std {
     template<>
@@ -239,7 +313,7 @@ test_unordered_map(){
     std::unordered_map<random_key, A> anunordered_map;
     anunordered_map.insert(std::make_pair(random_key(), A()));
     anunordered_map.insert(std::make_pair(random_key(), A()));
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("anunorderedmap",anunordered_map);
@@ -270,7 +344,7 @@ test_unordered_multimap(){
     std::unordered_multimap<random_key, A> anunordered_multimap;
     anunordered_multimap.insert(std::make_pair(random_key(), A()));
     anunordered_multimap.insert(std::make_pair(random_key(), A()));
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("anunordered_multimap", anunordered_multimap);
@@ -299,16 +373,19 @@ int test_main( int /* argc */, char* /* argv */[] )
     test_map();
     test_map_2();
     test_multimap();
-    
+
     #ifdef BOOST_HAS_HASH
     test_hash_map();
     test_hash_multimap();
     #endif
-    
+
+    test_boost_unordered_map();
+    test_boost_unordered_multimap();
+
     #ifndef BOOST_NO_CXX11_HDR_UNORDERED_MAP
     test_unordered_map();
     test_unordered_multimap();
     #endif
-    
+
     return EXIT_SUCCESS;
 }

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -1,8 +1,9 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // test_set.cpp
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // (C) Copyright 2014 Jim Bell
+// (C) Copyright 2015 Christoph Weiss
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -25,7 +26,7 @@ namespace std{
 
 #include <boost/detail/workaround.hpp>
 #if defined(BOOST_NO_STDC_NAMESPACE)
-namespace std{ 
+namespace std{
     using ::remove;
 }
 #endif
@@ -49,7 +50,7 @@ test_set(){
     std::set<A> aset;
     aset.insert(A());
     aset.insert(A());
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("aset", aset);
@@ -61,7 +62,7 @@ test_set(){
         ia >> boost::serialization::make_nvp("aset", aset1);
     }
     BOOST_CHECK(aset == aset1);
-    std::remove(testfile);    
+    std::remove(testfile);
 }
 
 void
@@ -72,7 +73,7 @@ test_multiset(){
     std::multiset<A> amultiset;
     amultiset.insert(A());
     amultiset.insert(A());
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("amultiset", amultiset);
@@ -110,7 +111,7 @@ test_hash_set(){
     A a, a1;
     ahash_set.insert(a);
     ahash_set.insert(a1);
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("ahash_set", ahash_set);
@@ -140,7 +141,7 @@ test_hash_multiset(){
     BOOST_STD_EXTENSION_NAMESPACE::hash_multiset<A> ahash_multiset;
     ahash_multiset.insert(A());
     ahash_multiset.insert(A());
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("ahash_multiset", ahash_multiset);
@@ -165,10 +166,83 @@ test_hash_multiset(){
 }
 #endif
 
-#ifndef BOOST_NO_CXX11_HDR_UNORDERED_SET
-
 #include <boost/serialization/unordered_set.hpp>
 #include <functional> // requires changeset [69520]; Ticket #5254
+
+namespace boost {
+    template<>
+    struct hash<A> {
+        std::size_t operator()(const A& a) const {
+            return static_cast<std::size_t>(a);
+        }
+    };
+} // namespace boost
+
+void
+test_boost_unordered_set(){
+    const char * testfile = boost::archive::tmpnam(NULL);
+    BOOST_REQUIRE(NULL != testfile);
+
+    // test array of objects
+    boost::unordered_set<A> anunordered_set;
+    A a, a1;
+    anunordered_set.insert(a);
+    anunordered_set.insert(a1);
+    {
+        test_ostream os(testfile, TEST_STREAM_FLAGS);
+        test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
+        oa << boost::serialization::make_nvp("anunordered_set", anunordered_set);
+    }
+    boost::unordered_set<A> anunordered_set1;
+    {
+        test_istream is(testfile, TEST_STREAM_FLAGS);
+        test_iarchive ia(is, TEST_ARCHIVE_FLAGS);
+        ia >> boost::serialization::make_nvp("anunordered_set", anunordered_set1);
+    }
+    std::vector<A> tvec, tvec1;
+    tvec.clear();
+    tvec1.clear();
+    std::copy(anunordered_set.begin(), anunordered_set.end(), std::back_inserter(tvec));
+    std::sort(tvec.begin(), tvec.end());
+    std::copy(anunordered_set1.begin(), anunordered_set1.end(), std::back_inserter(tvec1));
+    std::sort(tvec1.begin(), tvec1.end());
+    BOOST_CHECK(tvec == tvec1);
+    std::remove(testfile);
+}
+
+void
+test_boost_unordered_multiset(){
+    const char * testfile = boost::archive::tmpnam(NULL);
+    BOOST_REQUIRE(NULL != testfile);
+
+    boost::unordered_multiset<A> anunordered_multiset;
+    anunordered_multiset.insert(A());
+    anunordered_multiset.insert(A());
+    {
+        test_ostream os(testfile, TEST_STREAM_FLAGS);
+        test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
+        oa << boost::serialization::make_nvp("anunordered_multiset", anunordered_multiset);
+    }
+    boost::unordered_multiset<A> anunordered_multiset1;
+    {
+        test_istream is(testfile, TEST_STREAM_FLAGS);
+        test_iarchive ia(is, TEST_ARCHIVE_FLAGS);
+        ia >> boost::serialization::make_nvp("anunordered_multiset", anunordered_multiset1);
+    }
+
+    std::vector<A> tvec, tvec1;
+    tvec.clear();
+    tvec1.clear();
+    std::copy(anunordered_multiset.begin(), anunordered_multiset.end(), std::back_inserter(tvec));
+    std::sort(tvec.begin(), tvec.end());
+    std::copy(anunordered_multiset1.begin(), anunordered_multiset1.end(), std::back_inserter(tvec1));
+    std::sort(tvec1.begin(), tvec1.end());
+    BOOST_CHECK(tvec == tvec1);
+
+    std::remove(testfile);
+}
+
+#ifndef BOOST_NO_CXX11_HDR_UNORDERED_SET
 
 namespace std {
     template<>
@@ -189,7 +263,7 @@ test_unordered_set(){
     A a, a1;
     anunordered_set.insert(a);
     anunordered_set.insert(a1);
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("anunordered_set", anunordered_set);
@@ -219,7 +293,7 @@ test_unordered_multiset(){
     std::unordered_multiset<A> anunordered_multiset;
     anunordered_multiset.insert(A());
     anunordered_multiset.insert(A());
-    {   
+    {
         test_ostream os(testfile, TEST_STREAM_FLAGS);
         test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
         oa << boost::serialization::make_nvp("anunordered_multiset", anunordered_multiset);
@@ -247,16 +321,19 @@ test_unordered_multiset(){
 int test_main( int /* argc */, char* /* argv */[] ){
     test_set();
     test_multiset();
-    
+
     #ifdef BOOST_HAS_HASH
     test_hash_set();
     test_hash_multiset();
     #endif
-    
+
+    test_boost_unordered_set();
+    test_boost_unordered_multiset();
+
     #ifndef BOOST_NO_CXX11_HDR_UNORDERED_SET
-	test_unordered_set();
-	test_unordered_multiset();
+    test_unordered_set();
+    test_unordered_multiset();
     #endif
-    
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The code definitely a lot of copy & paste since I didn't want to break any compilers or anything --- one could probably use enable_if to make things a little bit cleaner.