### PR TITLE
Don't use thread unsafe wide character processing functions.

### DIFF
--- a/include/boost/archive/impl/xml_iarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_iarchive_impl.ipp
@@ -18,10 +18,11 @@ namespace std{
 #endif
 
 #ifndef BOOST_NO_CWCHAR
-#include <cstdlib> // mbtowc
+#include <cwchar> // mbstate_t and mbrtowc
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{ 
-    using ::mbtowc;
+    using ::mbstate_t;
+    using ::mbrtowc;
  } // namespace std
 #endif
 #endif // BOOST_NO_CWCHAR
@@ -64,11 +65,13 @@ xml_iarchive_impl<Archive>::load(std::wstring &ws){
     if(NULL != ws.data())
     #endif
         ws.resize(0);
+    std::mbstate_t mbs;
+    std::mbrtowc(0, 0, 0, &mbs);
     const char * start = s.data();
     const char * end = start + s.size();
     while(start < end){
         wchar_t wc;
-        int resultx = std::mbtowc(&wc, start, end - start);
+        int resultx = std::mbrtowc(&wc, start, end - start, &mbs);
         if(0 < resultx){
             start += resultx;
             ws += wc;
@@ -94,11 +97,13 @@ xml_iarchive_impl<Archive>::load(wchar_t * ws){
             xml_archive_exception(xml_archive_exception::xml_archive_parsing_error)
         );
         
+    std::mbstate_t mbs;
+    std::mbrtowc(0, 0, 0, &mbs);
     const char * start = s.data();
     const char * end = start + s.size();
     while(start < end){
         wchar_t wc;
-        int length = std::mbtowc(&wc, start, end - start);
+        int length = std::mbrtowc(&wc, start, end - start, &mbs);
         if(0 < length){
             start += length;
             *ws++ = wc;

--- a/include/boost/archive/iterators/mb_from_wchar.hpp
+++ b/include/boost/archive/iterators/mb_from_wchar.hpp
@@ -18,13 +18,14 @@
 
 #include <boost/assert.hpp>
 #include <cstddef> // size_t
-#include <cstdlib> // for wctomb()
+#include <cwchar> // for mbstate_t and wcrtomb()
 
 #include <boost/config.hpp>
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{ 
     using ::size_t; 
-    using ::wctomb;
+    using ::mbstate_t;
+    using ::wcrtomb;
 } // namespace std
 #endif
 
@@ -82,13 +83,10 @@ class mb_from_wchar
     }
 
     void fill(){
+        std::mbstate_t mbs;
+        std::wcrtomb(0, 0, &mbs);
         wchar_t value = * this->base_reference();
-        #if (defined(__MINGW32__) && ((__MINGW32_MAJOR_VERSION > 3) \
-        || ((__MINGW32_MAJOR_VERSION == 3) && (__MINGW32_MINOR_VERSION >= 8))))
-        m_bend = std::wcrtomb(m_buffer, value,0);
-        #else
-        m_bend = std::wctomb(m_buffer, value);
-        #endif
+        m_bend = std::wcrtomb(m_buffer, value, &mbs);
         BOOST_ASSERT(-1 != m_bend);
         BOOST_ASSERT((std::size_t)m_bend <= sizeof(m_buffer));
         BOOST_ASSERT(m_bend > 0);


### PR DESCRIPTION
The mbtowc(), wctomb() and mblen() functions are not supposed to be
thread-safe, as they have to keep parsing state in a global variable.
The mbrtowc(), wcrtomb() and mbrlen() functions should be used instead.

This change also simplifies how wchar_from_mb<Base>::drain() works.
There is no need to first iterate over the input using mblen().
mbrtowc() can store the partially parsed multibyte character in its
mbstate_t.