### PR TITLE
__visibility__ in forward decl

### DIFF
--- a/include/boost/archive/detail/interface_oarchive.hpp
+++ b/include/boost/archive/detail/interface_oarchive.hpp
@@ -29,7 +29,7 @@ namespace boost {
 namespace archive {
 namespace detail {
 
-class BOOST_ARCHIVE_OR_WARCHIVE_DECL basic_pointer_oserializer;
+class basic_pointer_oserializer;
 
 template<class Archive>
 class interface_oarchive 

--- a/include/boost/archive/polymorphic_iarchive.hpp
+++ b/include/boost/archive/polymorphic_iarchive.hpp
@@ -43,8 +43,7 @@ namespace serialization {
 } // namespace serialization
 namespace archive {
 namespace detail {
-    class BOOST_ARCHIVE_DECL basic_iarchive;
-    class BOOST_ARCHIVE_DECL basic_iarchive;
+    class basic_iarchive;
 }
 
 class polymorphic_iarchive;

--- a/include/boost/archive/polymorphic_oarchive.hpp
+++ b/include/boost/archive/polymorphic_oarchive.hpp
@@ -42,8 +42,8 @@ namespace serialization {
 } // namespace serialization
 namespace archive {
 namespace detail {
-    class BOOST_ARCHIVE_DECL basic_oarchive;
-    class BOOST_ARCHIVE_DECL basic_oserializer;
+    class basic_oarchive;
+    class basic_oserializer;
 }
 
 class polymorphic_oarchive;


### PR DESCRIPTION
The visibility spec  does not seems to be relevant on forward class decalarations and it trigger a lot of spurious warning with intel icpc in linux.