### PR TITLE
Change archives to backup and restore the C++ locale:

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -80,6 +80,7 @@ SOURCES =
     xml_iarchive
     xml_oarchive
     xml_archive_exception
+    utf8_codecvt_facet
 ;
     
 WSOURCES = 
@@ -87,7 +88,6 @@ WSOURCES =
     basic_text_woprimitive
     text_wiarchive
     text_woarchive
-    utf8_codecvt_facet
     xml_wgrammar
     xml_wiarchive
     xml_woarchive

--- a/include/boost/archive/basic_text_iprimitive.hpp
+++ b/include/boost/archive/basic_text_iprimitive.hpp
@@ -26,6 +26,7 @@
 
 #include <locale>
 #include <cstddef> // size_t
+#include <limits>
 
 #include <boost/config.hpp>
 #if defined(BOOST_NO_STDC_NAMESPACE)

--- a/include/boost/archive/impl/basic_binary_iprimitive.ipp
+++ b/include/boost/archive/impl/basic_binary_iprimitive.ipp
@@ -154,7 +154,7 @@ basic_binary_iprimitive<Archive, Elem, Tr>::basic_binary_iprimitive(
         archive_locale = m_sb.pubimbue(archive_locale);
     }
     else
-        archive_locale = std::locale();
+        archive_locale = m_sb.getloc();
 }
 #else
     m_sb(sb)

--- a/include/boost/archive/impl/basic_binary_iprimitive.ipp
+++ b/include/boost/archive/impl/basic_binary_iprimitive.ipp
@@ -151,8 +151,10 @@ basic_binary_iprimitive<Archive, Elem, Tr>::basic_binary_iprimitive(
     archive_locale(sb.getloc(), & codecvt_null_facet)
 {
     if(! no_codecvt){
-        m_sb.pubimbue(archive_locale);
+        archive_locale = m_sb.pubimbue(archive_locale);
     }
+    else
+        archive_locale = std::locale();
 }
 #else
     m_sb(sb)
@@ -190,6 +192,9 @@ basic_binary_iprimitive<Archive, Elem, Tr>::~basic_binary_iprimitive(){
     //destructor can't throw !
     BOOST_TRY{
         static_cast<detail::input_streambuf_access<Elem, Tr> &>(m_sb).sync();
+#ifndef BOOST_NO_STD_LOCALE
+        m_sb.pubimbue(archive_locale);
+#endif
     }
     BOOST_CATCH(...){
     }

--- a/include/boost/archive/impl/basic_binary_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_binary_oprimitive.ipp
@@ -107,7 +107,7 @@ basic_binary_oprimitive<Archive, Elem, Tr>::basic_binary_oprimitive(
         archive_locale = m_sb.pubimbue(archive_locale);
     }
     else
-        archive_locale = std::locale();
+        archive_locale = m_sb.getloc();
 }
 #else
     m_sb(sb)

--- a/include/boost/archive/impl/basic_binary_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_binary_oprimitive.ipp
@@ -104,8 +104,10 @@ basic_binary_oprimitive<Archive, Elem, Tr>::basic_binary_oprimitive(
     archive_locale(sb.getloc(), & codecvt_null_facet)
 {
     if(! no_codecvt){
-        m_sb.pubimbue(archive_locale);
+        archive_locale = m_sb.pubimbue(archive_locale);
     }
+    else
+        archive_locale = std::locale();
 }
 #else
     m_sb(sb)
@@ -143,6 +145,9 @@ basic_binary_oprimitive<Archive, Elem, Tr>::~basic_binary_oprimitive(){
     //destructor can't throw
     BOOST_TRY{
         static_cast<detail::output_streambuf_access<Elem, Tr> &>(m_sb).sync();
+#ifndef BOOST_NO_STD_LOCALE
+        m_sb.pubimbue(archive_locale);
+#endif
     }
     BOOST_CATCH(...){
     }

--- a/include/boost/archive/impl/basic_text_iprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_iprimitive.ipp
@@ -118,8 +118,10 @@ basic_text_iprimitive<IStream>::basic_text_iprimitive(
     archive_locale(is_.getloc(), & codecvt_null_facet)
 {
     if(! no_codecvt){
-        is.imbue(archive_locale);
+        archive_locale = is.imbue(archive_locale);
     }
+    else
+        archive_locale = std::locale();
     is >> std::noboolalpha;
 }
 #else
@@ -129,6 +131,9 @@ basic_text_iprimitive<IStream>::basic_text_iprimitive(
 template<class IStream>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL
 basic_text_iprimitive<IStream>::~basic_text_iprimitive(){
+#ifndef BOOST_NO_STD_LOCALE
+    is.imbue(archive_locale);
+#endif
 }
 
 } // namespace archive

--- a/include/boost/archive/impl/basic_text_iprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_iprimitive.ipp
@@ -121,7 +121,7 @@ basic_text_iprimitive<IStream>::basic_text_iprimitive(
         archive_locale = is.imbue(archive_locale);
     }
     else
-        archive_locale = std::locale();
+        archive_locale = is.getloc();
     is >> std::noboolalpha;
 }
 #else

--- a/include/boost/archive/impl/basic_text_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_oprimitive.ipp
@@ -95,7 +95,7 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
         archive_locale = os.imbue(archive_locale);
     }
     else
-        archive_locale = std::locale();
+        archive_locale = os.getloc();
     os << std::noboolalpha;
 }
 #else

--- a/include/boost/archive/impl/basic_text_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_oprimitive.ipp
@@ -92,8 +92,10 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
     archive_locale(os_.getloc(), & codecvt_null_facet)
 {
     if(! no_codecvt){
-        os.imbue(archive_locale);
+        archive_locale = os.imbue(archive_locale);
     }
+    else
+        archive_locale = std::locale();
     os << std::noboolalpha;
 }
 #else
@@ -105,6 +107,9 @@ template<class OStream>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL
 basic_text_oprimitive<OStream>::~basic_text_oprimitive(){
     os << std::endl;
+#ifndef BOOST_NO_STD_LOCALE
+    os.imbue(archive_locale);
+#endif
 }
 
 } //namespace boost 

--- a/include/boost/archive/impl/xml_wiarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_wiarchive_impl.ipp
@@ -164,7 +164,7 @@ xml_wiarchive_impl<Archive>::xml_wiarchive_impl(
         archive_locale = is.imbue(archive_locale);
     }
     else
-        archive_locale = std::locale();
+        archive_locale = is.getloc();
     if(0 == (flags & no_header))
         init();
 }

--- a/include/boost/archive/impl/xml_wiarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_wiarchive_impl.ipp
@@ -161,8 +161,10 @@ xml_wiarchive_impl<Archive>::xml_wiarchive_impl(
     gimpl(new xml_wgrammar())
 {
     if(0 == (flags & no_codecvt)){
-        is.imbue(archive_locale);
+        archive_locale = is.imbue(archive_locale);
     }
+    else
+        archive_locale = std::locale();
     if(0 == (flags & no_header))
         init();
 }
@@ -173,6 +175,7 @@ xml_wiarchive_impl<Archive>::~xml_wiarchive_impl(){
     if(0 == (this->get_flags() & no_header)){
         gimpl->windup(is);
     }
+    is.imbue(archive_locale);
 }
 
 } // namespace archive

--- a/include/boost/archive/impl/xml_woarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_woarchive_impl.ipp
@@ -128,8 +128,10 @@ xml_woarchive_impl<Archive>::xml_woarchive_impl(
     // transforms (such as one to many transforms from getting
     // mixed up.
     if(0 == (flags & no_codecvt)){
-        os.imbue(archive_locale);
+        archive_locale = os.imbue(archive_locale);
     }
+    else
+        archive_locale = std::locale();
     if(0 == (flags & no_header))
         this->init();
 }
@@ -137,6 +139,7 @@ xml_woarchive_impl<Archive>::xml_woarchive_impl(
 template<class Archive>
 BOOST_WARCHIVE_DECL
 xml_woarchive_impl<Archive>::~xml_woarchive_impl(){
+    os.imbue(archive_locale);
 }
 
 } // namespace archive

--- a/include/boost/archive/impl/xml_woarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_woarchive_impl.ipp
@@ -131,7 +131,7 @@ xml_woarchive_impl<Archive>::xml_woarchive_impl(
         archive_locale = os.imbue(archive_locale);
     }
     else
-        archive_locale = std::locale();
+        archive_locale = os.getloc();
     if(0 == (flags & no_header))
         this->init();
 }


### PR DESCRIPTION
avoids double delete of the locale's facets.
Move utf8_codecvt_facet.cpp into main library as it's referenced from there.
