### PR TITLE
Changes to get things linking correctly with msvc:

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -80,6 +80,8 @@ SOURCES =
     xml_iarchive
     xml_oarchive
     xml_archive_exception
+    codecvt_null
+    utf8_codecvt_facet
 ;
     
 WSOURCES = 
@@ -87,11 +89,9 @@ WSOURCES =
     basic_text_woprimitive
     text_wiarchive
     text_woarchive
-    utf8_codecvt_facet
     xml_wgrammar
     xml_wiarchive
     xml_woarchive
-    codecvt_null
 ;
 
 lib boost_serialization 

--- a/include/boost/archive/codecvt_null.hpp
+++ b/include/boost/archive/codecvt_null.hpp
@@ -61,7 +61,7 @@ public:
 template<>
 class codecvt_null<wchar_t> : public std::codecvt<wchar_t, char, std::mbstate_t>
 {
-    virtual BOOST_WARCHIVE_DECL std::codecvt_base::result
+    virtual BOOST_ARCHIVE_DECL std::codecvt_base::result
     do_out(
         std::mbstate_t & state,
         const wchar_t * first1,
@@ -71,7 +71,7 @@ class codecvt_null<wchar_t> : public std::codecvt<wchar_t, char, std::mbstate_t>
         char * last2,
         char * & next2
     ) const;
-    virtual BOOST_WARCHIVE_DECL std::codecvt_base::result
+    virtual BOOST_ARCHIVE_DECL std::codecvt_base::result
     do_in(
         std::mbstate_t & state,
         const char * first1,

--- a/src/codecvt_null.cpp
+++ b/src/codecvt_null.cpp
@@ -7,7 +7,7 @@
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#define BOOST_WARCHIVE_SOURCE
+#define BOOST_ARCHIVE_SOURCE
 #include <boost/archive/codecvt_null.hpp>
 
 // codecvt implementation for passing wchar_t objects to char output
@@ -17,7 +17,7 @@
 namespace boost {
 namespace archive {
 
-BOOST_WARCHIVE_DECL std::codecvt_base::result
+BOOST_ARCHIVE_DECL std::codecvt_base::result
 codecvt_null<wchar_t>::do_out(
     std::mbstate_t & /*state*/,
     const wchar_t * first1, 
@@ -45,7 +45,7 @@ codecvt_null<wchar_t>::do_out(
     return std::codecvt_base::ok;
 }
 
-BOOST_WARCHIVE_DECL std::codecvt_base::result
+BOOST_ARCHIVE_DECL std::codecvt_base::result
 codecvt_null<wchar_t>::do_in(
     std::mbstate_t & /*state*/,
     const char * first1, 

--- a/src/utf8_codecvt_facet.cpp
+++ b/src/utf8_codecvt_facet.cpp
@@ -3,14 +3,16 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define BOOST_ARCHIVE_SOURCE
 #include <boost/config.hpp>
+#include <boost/archive/detail/auto_link_archive.hpp>
 #ifdef BOOST_NO_STD_WSTREAMBUF
 #error "wide char i/o not supported on this platform"
 #else
     #ifdef BOOST_NO_CXX11_HDR_CODECVT
         #define BOOST_UTF8_BEGIN_NAMESPACE \
              namespace boost { namespace archive { namespace detail {
-        #define BOOST_UTF8_DECL
+        #define BOOST_UTF8_DECL BOOST_ARCHIVE_DECL
         #define BOOST_UTF8_END_NAMESPACE }}}
         #include <boost/detail/utf8_codecvt_facet.ipp>
         #undef BOOST_UTF8_END_NAMESPACE


### PR DESCRIPTION
1) Move the two facets utf8_codecvt_facet and codecvt_null into
the main serialization archive as they get referenced from xml_oarchive.obj.
2) Add DLL-interface to utf8_codecvt_facet.
3) Change codecvt_null to use narrow character DLL interface macros.