### PR TITLE
Fix order of destruction of state-saver.

### DIFF
--- a/include/boost/archive/basic_text_iprimitive.hpp
+++ b/include/boost/archive/basic_text_iprimitive.hpp
@@ -68,12 +68,12 @@ protected:
     io::ios_precision_saver precision_saver;
 
     #ifndef BOOST_NO_STD_LOCALE
+    boost::archive::codecvt_null<typename IStream::char_type> codecvt_null_facet;
+    std::locale archive_locale;
     basic_streambuf_locale_saver<
         typename IStream::char_type, 
         typename IStream::traits_type
     > locale_saver;
-    boost::archive::codecvt_null<typename IStream::char_type> codecvt_null_facet;
-    std::locale archive_locale;
     #endif
 
     template<class T>

--- a/include/boost/archive/basic_text_oprimitive.hpp
+++ b/include/boost/archive/basic_text_oprimitive.hpp
@@ -71,12 +71,12 @@ protected:
     io::ios_precision_saver precision_saver;
 
     #ifndef BOOST_NO_STD_LOCALE
+    boost::archive::codecvt_null<typename OStream::char_type> codecvt_null_facet;
+    std::locale archive_locale;
     basic_streambuf_locale_saver<
         typename OStream::char_type,
         typename OStream::traits_type
     > locale_saver;
-    boost::archive::codecvt_null<typename OStream::char_type> codecvt_null_facet;
-    std::locale archive_locale;
     #endif
 
     /////////////////////////////////////////////////////////

--- a/include/boost/archive/impl/basic_text_iprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_iprimitive.ipp
@@ -114,9 +114,9 @@ basic_text_iprimitive<IStream>::basic_text_iprimitive(
     flags_saver(is_),
     precision_saver(is_),
 #ifndef BOOST_NO_STD_LOCALE
-    locale_saver(* is.rdbuf()),
     codecvt_null_facet(1),
-    archive_locale(is.rdbuf()->getloc(), & codecvt_null_facet)
+    archive_locale(is.rdbuf()->getloc(), & codecvt_null_facet),
+    locale_saver(* is.rdbuf())
 {
     if(! no_codecvt){
         is.rdbuf()->pubimbue(archive_locale);

--- a/include/boost/archive/impl/basic_text_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_oprimitive.ipp
@@ -88,9 +88,9 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
     flags_saver(os_),
     precision_saver(os_),
 #ifndef BOOST_NO_STD_LOCALE
-    locale_saver(* os.rdbuf()),
     codecvt_null_facet(1),
-    archive_locale(os.rdbuf()->getloc(), & codecvt_null_facet)
+    archive_locale(os.rdbuf()->getloc(), & codecvt_null_facet),
+    locale_saver(* os.rdbuf())
 {
     if(! no_codecvt){
         os.rdbuf()->pubimbue(archive_locale);


### PR DESCRIPTION
Without this patch member codecvt_null_facet is destroyed before the locale is restored to the stream buffer resulting in a program crash.
