### PR TITLE
Fix MSVC compilation errors

### DIFF
--- a/src/extended_type_info.cpp
+++ b/src/extended_type_info.cpp
@@ -26,10 +26,11 @@ namespace std{ using ::strcmp; }
 #endif
 
 #include <boost/core/no_exceptions_support.hpp>
+
+#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/singleton.hpp>
 #include <boost/serialization/force_include.hpp>
 
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/extended_type_info.hpp>
 
 #ifdef BOOST_MSVC

--- a/src/extended_type_info_typeid.cpp
+++ b/src/extended_type_info_typeid.cpp
@@ -17,9 +17,9 @@
 
 #include <boost/core/no_exceptions_support.hpp>
 
+#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/singleton.hpp>
 
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/extended_type_info_typeid.hpp>
 
 namespace boost { 


### PR DESCRIPTION
BOOST_SERIALIZATION_SOURCE has to be defined before the first
serialization/config.hpp include. As singleton.hpp also includes config.hpp
now, BOOST_SERIALIZATION_DECL was defined as BOOST_SYMBOL_IMPORT instead of
BOOST_SYMBOL_EXPORT in the serialization source files, leading to C2491
"definition of dllimport function not allowed" errors on MSVC when building
serialization as a shared library.