### PR TITLE
Add missing includes for some stl containers

### DIFF
--- a/include/boost/serialization/detail/stack_constructor.hpp
+++ b/include/boost/serialization/detail/stack_constructor.hpp
@@ -17,6 +17,7 @@
 //  See http://www.boost.org for updates, documentation, and revision history.
 
 #include <boost/aligned_storage.hpp>
+#include <boost/serialization/serialization.hpp>
 
 namespace boost{
 namespace serialization {

--- a/include/boost/serialization/priority_queue.hpp
+++ b/include/boost/serialization/priority_queue.hpp
@@ -18,6 +18,8 @@
 
 #include <queue>
 #include <boost/config.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
 
 // function specializations must be defined in the appropriate
 // namespace - boost::serialization

--- a/include/boost/serialization/queue.hpp
+++ b/include/boost/serialization/queue.hpp
@@ -18,6 +18,8 @@
 
 #include <queue>
 #include <boost/config.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
 
 // function specializations must be defined in the appropriate
 // namespace - boost::serialization

--- a/include/boost/serialization/stack.hpp
+++ b/include/boost/serialization/stack.hpp
@@ -18,6 +18,8 @@
 
 #include <stack>
 #include <boost/config.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
 
 // function specializations must be defined in the appropriate
 // namespace - boost::serialization


### PR DESCRIPTION
Just including the corresponding header for the stl container should work, but leads to a build failure for some of the containers due to missing includes.