### PR TITLE
fix bugs in macro BOOST_SERIALIZATION_FACTORY

### DIFF
--- a/include/boost/serialization/factory.hpp
+++ b/include/boost/serialization/factory.hpp
@@ -48,27 +48,29 @@ namespace boost {                                         \
 namespace serialization {                                 \
     template<>                                            \
     T * factory<T, N>(std::va_list ap){                   \
-        BOOST_PP_IF(BOOST_PP_GREATER(N,0)                 \
-            ,A0 a0 = va_arg(ap, A0);                      \
-        ,BOOST_PP_IF(BOOST_PP_GREATER(N,1)                \
-            ,A1 a1 = va_arg(ap, A1);                      \
-        ,BOOST_PP_IF(BOOST_PP_GREATER(N,2)                \
-            ,A2 a2 = va_arg(ap, A2);                      \
-        ,BOOST_PP_IF(BOOST_PP_GREATER(N,3)                \
-            ,A3 a3 = va_arg(ap, A3);                      \
-            ,BOOST_PP_EMPTY()                             \
-        ))))                                              \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 0)                \
+            , A0 a0 = va_arg(ap, A0);, BOOST_PP_EMPTY())  \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 1)                 \
+            , A1 a1 = va_arg(ap, A1);, BOOST_PP_EMPTY())  \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 2)                 \
+            , A2 a2 = va_arg(ap, A2);, BOOST_PP_EMPTY())  \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 3)                 \
+            , A3 a3 = va_arg(ap, A3);, BOOST_PP_EMPTY())  \
         return new T(                                     \
-            BOOST_PP_IF(BOOST_PP_GREATER(N,0)             \
-                ,a0                                       \
-            ,BOOST_PP_IF(BOOST_PP_GREATER(N,1)            \
-                ,a1                                       \
-            ,BOOST_PP_IF(BOOST_PP_GREATER(N,2)            \
-                ,a2                                       \
-            ,BOOST_PP_IF(BOOST_PP_GREATER(N,3)            \
-                ,a3                                       \
-                ,BOOST_PP_EMPTY()                         \
-            ))))                                          \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 0)            \
+                , a0, BOOST_PP_EMPTY())                   \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 1))           \
+                , BOOST_PP_COMMA, BOOST_PP_EMPTY)()       \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 1)            \
+                , a1, BOOST_PP_EMPTY())                   \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 2))           \
+                , BOOST_PP_COMMA, BOOST_PP_EMPTY)()       \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 2)            \
+                , a2, BOOST_PP_EMPTY())                   \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 3))           \
+                , BOOST_PP_COMMA, BOOST_PP_EMPTY)()       \
+            BOOST_PP_IF(BOOST_PP_GREATER(N, 3)            \
+                , a3, BOOST_PP_EMPTY())                   \
         );                                                \
     }                                                     \
 }                                                         \

--- a/include/boost/serialization/factory.hpp
+++ b/include/boost/serialization/factory.hpp
@@ -50,11 +50,11 @@ namespace serialization {                                 \
     T * factory<T, N>(std::va_list ap){                   \
         BOOST_PP_IF(BOOST_PP_GREATER(N, 0)                \
             , A0 a0 = va_arg(ap, A0);, BOOST_PP_EMPTY())  \
-        BOOST_PP_IF(BOOST_PP_GREATER(N, 1)                 \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 1)                \
             , A1 a1 = va_arg(ap, A1);, BOOST_PP_EMPTY())  \
-        BOOST_PP_IF(BOOST_PP_GREATER(N, 2)                 \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 2)                \
             , A2 a2 = va_arg(ap, A2);, BOOST_PP_EMPTY())  \
-        BOOST_PP_IF(BOOST_PP_GREATER(N, 3)                 \
+        BOOST_PP_IF(BOOST_PP_GREATER(N, 3)                \
             , A3 a3 = va_arg(ap, A3);, BOOST_PP_EMPTY())  \
         return new T(                                     \
             BOOST_PP_IF(BOOST_PP_GREATER(N, 0)            \


### PR DESCRIPTION
Just first argument `A0` can be invoked in T's constructor.
