### PR TITLE
use std::addressof (or boost::addressof) to make serialization work w…

### DIFF
--- a/include/boost/archive/detail/oserializer.hpp
+++ b/include/boost/archive/detail/oserializer.hpp
@@ -252,7 +252,8 @@ struct save_non_pointer_type {
         template<class T>
         static void invoke(Archive &ar, const T & t){
             ar.save_object(
-                & t, 
+            //    & t,
+                std::addressof(t),
                 boost::serialization::singleton<
                     oserializer<Archive, T>
                 >::get_const_instance()


### PR DESCRIPTION
…ith class with unary operator&()

I have a class that overloads the unary operator&() the only way I was able to make it work was to modify the library. 
There may be a non intrusive way by creating a proxy return of operator& that can be casted to the right pointer or to the other use but requires a lot of hacking an unnecessary performance hit.