### PR TITLE
bad make_array friend declaration

### DIFF
--- a/include/boost/serialization/array.hpp
+++ b/include/boost/serialization/array.hpp
@@ -44,7 +44,7 @@ public:
     // note: I would like to make the copy constructor private but this breaks
     // make_array.  So I try to make make_array a friend - but that doesn't
     // build.  Need a C++ guru to explain this!
-    template<class S>
+    template<class T, class S>
     friend const boost::serialization::array_wrapper<T> make_array( T* t, S s);
 
     array_wrapper(const array_wrapper & rhs) :


### PR DESCRIPTION
The friend declaration introduce a function declaration of make_array with one template parameter which does not exist.

There is an inline make_array declaration with two templates parameters, I'm guessing that's the one we want to use.
Using T as a template parameter which mask an existing enclosing parameter in order to match the inline function definition names. Masking in a friend decl should not be an issue.
