### PR TITLE
Remove explicit check for <forward_list>

### DIFF
--- a/include/boost/serialization/forward_list.hpp
+++ b/include/boost/serialization/forward_list.hpp
@@ -17,9 +17,6 @@
 //  See http://www.boost.org for updates, documentation, and revision history.
 
 #include <boost/config.hpp>
-#ifdef BOOST_NO_CXX11_HDR_FORWARD_LIST
-#error "This header depends upon the existence of <forward_list>
-#endif
 
 #include <forward_list>
 #include <iterator>  // distance

--- a/test/test_forward_list.cpp
+++ b/test/test_forward_list.cpp
@@ -18,9 +18,6 @@ namespace std{
 #endif
 
 #include <boost/config.hpp>
-#ifdef BOOST_NO_CXX11_HDR_FORWARD_LIST
-#error This test presumes support for <forward_list>
-#endif
 #include <boost/serialization/forward_list.hpp>
 
 #include <boost/archive/archive_exception.hpp>


### PR DESCRIPTION
This removes the `#error` directives when `BOOST_NO_CXX11_HDR_FORWARD_LIST` is defined, to make the tests pass on clang-darwin.