### PR TITLE
[Ticket #12144] Don't use defined in a macro definition.

### DIFF
--- a/include/boost/archive/detail/iserializer.hpp
+++ b/include/boost/archive/detail/iserializer.hpp
@@ -57,11 +57,8 @@ namespace std{
 
 #include <boost/serialization/assume_abstract.hpp>
 
-#ifndef BOOST_MSVC
-    #define DONT_USE_HAS_NEW_OPERATOR (                    \
-           BOOST_WORKAROUND(__IBMCPP__, < 1210)            \
-        || defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590)   \
-    )
+#if BOOST_WORKAROUND(__IBMCPP__, < 1210) || (defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590))
+    #define DONT_USE_HAS_NEW_OPERATOR 1
 #else
     #define DONT_USE_HAS_NEW_OPERATOR 0
 #endif


### PR DESCRIPTION
Hi,

This should fix https://svn.boost.org/trac/boost/ticket/12144 (tested with clang 3.9 which doesn't throw any warning/error anymore).

Ok for the trunk ?

Cheers,
Romain