### PR TITLE
Build all source for library with BOOST_SERIALIZATION_SOURCE solves s…

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -107,6 +107,7 @@ lib boost_serialization
     <toolset>clang:<cxxflags>"-ftemplate-depth-255"
     <toolset>darwin:<cxxflags>"-ftemplate-depth-255"
     <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
+    <link>shared:<define>BOOST_SERIALIZATION_SOURCE
     ;
 
 lib boost_wserialization 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -107,7 +107,7 @@ lib boost_serialization
     <toolset>clang:<cxxflags>"-ftemplate-depth-255"
     <toolset>darwin:<cxxflags>"-ftemplate-depth-255"
     <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
-    <link>shared:<define>BOOST_SERIALIZATION_SOURCE
+    <define>BOOST_SERIALIZATION_SOURCE
     ;
 
 lib boost_wserialization 

--- a/src/basic_iarchive.cpp
+++ b/src/basic_iarchive.cpp
@@ -26,9 +26,6 @@ namespace std{
 #include <boost/integer_traits.hpp>
 
 #define BOOST_ARCHIVE_SOURCE
-// include this to prevent linker errors when the
-// same modules are marked export and import.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 
 #include <boost/serialization/state_saver.hpp>

--- a/src/basic_oarchive.cpp
+++ b/src/basic_oarchive.cpp
@@ -19,9 +19,6 @@
 // including this here to work around an ICC in intel 7.0
 // normally this would be part of basic_oarchive.hpp below.
 #define BOOST_ARCHIVE_SOURCE
-// include this to prevent linker errors when the
-// same modules are marked export and import.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 #include <boost/serialization/state_saver.hpp>
 #include <boost/serialization/throw_exception.hpp>

--- a/src/basic_serializer_map.cpp
+++ b/src/basic_serializer_map.cpp
@@ -16,9 +16,6 @@
 #include <utility>
 
 #define BOOST_ARCHIVE_SOURCE
-// include this to prevent linker errors when the
-// same modules are marked export and import.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 #include <boost/serialization/throw_exception.hpp>
 

--- a/src/extended_type_info.cpp
+++ b/src/extended_type_info.cpp
@@ -27,10 +27,6 @@ namespace std{ using ::strcmp; }
 
 #include <boost/core/no_exceptions_support.hpp>
 
-// it marks our code with proper attributes as being exported when
-// we're compiling it while marking it import when just the headers
-// is being included.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 #include <boost/serialization/singleton.hpp>
 #include <boost/serialization/force_include.hpp>

--- a/src/extended_type_info_no_rtti.cpp
+++ b/src/extended_type_info_no_rtti.cpp
@@ -18,10 +18,6 @@
 namespace std{ using ::strcmp; }
 #endif
 
-// it marks our code with proper attributes as being exported when
-// we're compiling it while marking it import when just the headers
-// is being included.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 #include <boost/serialization/extended_type_info_no_rtti.hpp>
 

--- a/src/extended_type_info_typeid.cpp
+++ b/src/extended_type_info_typeid.cpp
@@ -17,10 +17,6 @@
 
 #include <boost/core/no_exceptions_support.hpp>
 
-// it marks our code with proper attributes as being exported when
-// we're compiling it while marking it import when just the headers
-// is being included.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 #include <boost/serialization/singleton.hpp>
 #include <boost/serialization/extended_type_info_typeid.hpp>

--- a/src/singleton.cpp
+++ b/src/singleton.cpp
@@ -7,10 +7,6 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 //
 
-// it marks our code with proper attributes as being exported when
-// we're compiling it while marking it import when just the headers
-// is being included.
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 #include <boost/serialization/singleton.hpp>
 

--- a/src/void_cast.cpp
+++ b/src/void_cast.cpp
@@ -26,7 +26,6 @@
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
 
-#define BOOST_SERIALIZATION_SOURCE
 #include <boost/serialization/config.hpp>
 // it marks our code with proper attributes as being exported when
 // we're compiling it while marking it import when just the headers


### PR DESCRIPTION
…ingleton link problem. I have placed the BOOST_SERIALIZATION_SOURCE definition in the build jamfile so it applies to all the non-wide source, and removed it from each source file. Alternatively, if desired I could remove it from the jamfile and add it to each source file, but I felt the way I did it was easier. The important point to solving the singleton link problem for gcc under Windows is that the definition must apply to each source file in the build so that the build of the non-wide character serialization library sees the necessary classes/functions as exported.