### PR TITLE
Included boost/throw_exception.hpp when exceptions are disabled.

### DIFF
--- a/include/boost/serialization/throw_exception.hpp
+++ b/include/boost/serialization/throw_exception.hpp
@@ -19,6 +19,8 @@
 
 #ifndef BOOST_NO_EXCEPTIONS
 #include <exception>
+#else
+#include <boost/throw_exception.hpp>
 #endif
 
 namespace boost {


### PR DESCRIPTION
There is a compilation error when boost is compiled without exceptions: boost::serialization::throw_exception calls boost::throw_exception which is not declared in this case. The declaration is situated in boost/throw_exception.hpp.