### PR TITLE
Avoid undefined behavior.

### DIFF
--- a/include/boost/archive/detail/iserializer.hpp
+++ b/include/boost/archive/detail/iserializer.hpp
@@ -57,13 +57,12 @@ namespace std{
 
 #include <boost/serialization/assume_abstract.hpp>
 
-#ifndef BOOST_MSVC
-    #define DONT_USE_HAS_NEW_OPERATOR (                    \
-           BOOST_WORKAROUND(__IBMCPP__, < 1210)            \
-        || defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590)   \
-    )
+#if !defined(BOOST_MSVC) && \
+  (BOOST_WORKAROUND(__IBMCPP__, < 1210) || \
+   defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x590))
+#define DONT_USE_HAS_NEW_OPERATOR 1
 #else
-    #define DONT_USE_HAS_NEW_OPERATOR 0
+#define DONT_USE_HAS_NEW_OPERATOR 0
 #endif
 
 #if ! DONT_USE_HAS_NEW_OPERATOR


### PR DESCRIPTION
Macros expanding to defined() expressions are undefined, move the conditional logic to outside the expression.