### PR TITLE
Fixed compile error with FreeBSD libc.

### DIFF
--- a/include/boost/archive/iterators/escape.hpp
+++ b/include/boost/archive/iterators/escape.hpp
@@ -103,7 +103,7 @@ public:
         m_bnext(NULL),
         m_bend(NULL),
         m_full(false),
-        m_current_value(NULL)
+        m_current_value(0)
     {
     }
 };


### PR DESCRIPTION
FreeBSD libc defines NULL as nullptr in c++11 or later mode; nullptr cannot convert to arithmetic type.

see https://svnweb.freebsd.org/base/head/sys/sys/_null.h?r1=192002&r2=228918

This PR will fix many test failure, like [Test output: Flast-FreeBSD11 - serialization - test_iterators / clang-linux-3.8~gnu++11](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD11-boost-bin-v2-libs-serialization-test-test_iterators-test-clang-linux-3-8~gnu++11-debug.html).

Tested on FreeBSD 11.0 with clang 3.8.0.