### PR TITLE
Fix conversion operators of injected primitive types

### DIFF
--- a/include/boost/archive/basic_archive.hpp
+++ b/include/boost/archive/basic_archive.hpp
@@ -162,11 +162,11 @@ public:
         return *this;
     }
     // used for text output
-    operator uint_least32_t () const {
+    operator base_type () const {
         return t;
     }                
     // used for text input
-    operator uint_least32_t & () {
+    operator base_type & () {
         return t;
     }                
     bool operator==(const object_id_type & rhs) const {

--- a/include/boost/archive/basic_archive.hpp
+++ b/include/boost/archive/basic_archive.hpp
@@ -127,11 +127,11 @@ public:
     }
 
     // used for text output
-    operator int () const {
+    operator base_type () const {
         return t;
     }                
     // used for text input
-    operator int_least16_t &() {
+    operator base_type &() {
         return t;
     }                
     bool operator==(const class_id_type & rhs) const {


### PR DESCRIPTION
`archive::class_id_type`  conversion operators convert to different types for input (`int_least16_t`) and output (`int`) thus breaking archive pairs that rely on these being identical and do not explicitly define `.{save|load}_override` for `class_id_type`,  forwarding to corresponding primitive overload of `{save|load}` instead.

