### PR TITLE
Fixes I needed in order to build boostorg/uuid properly in Appveyor

### DIFF
--- a/include/boost/archive/codecvt_null.hpp
+++ b/include/boost/archive/codecvt_null.hpp
@@ -65,7 +65,7 @@ public:
 template<>
 class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> : public std::codecvt<wchar_t, char, std::mbstate_t>
 {
-    virtual BOOST_WARCHIVE_DECL BOOST_DLLEXPORT std::codecvt_base::result
+    virtual BOOST_WARCHIVE_DECL std::codecvt_base::result
     do_out(
         std::mbstate_t & state,
         const wchar_t * first1,
@@ -75,7 +75,7 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> : public std::codecvt<wchar_t, 
         char * last2,
         char * & next2
     ) const BOOST_USED;
-    virtual BOOST_WARCHIVE_DECL BOOST_DLLEXPORT std::codecvt_base::result
+    virtual BOOST_WARCHIVE_DECL std::codecvt_base::result
     do_in(
         std::mbstate_t & state,
         const char * first1,
@@ -92,7 +92,7 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> : public std::codecvt<wchar_t, 
         return do_encoding();
     }
 public:
-    BOOST_DLLEXPORT explicit codecvt_null(std::size_t no_locale_manage = 0) :
+    explicit codecvt_null(std::size_t no_locale_manage = 0) :
         std::codecvt<wchar_t, char, std::mbstate_t>(no_locale_manage)
     {}
     virtual ~codecvt_null(){};

--- a/src/codecvt_null.cpp
+++ b/src/codecvt_null.cpp
@@ -18,7 +18,7 @@
 namespace boost {
 namespace archive {
 
-BOOST_WARCHIVE_DECL BOOST_DLLEXPORT std::codecvt_base::result
+BOOST_WARCHIVE_DECL std::codecvt_base::result
 codecvt_null<wchar_t>::do_out(
     std::mbstate_t & /*state*/,
     const wchar_t * first1, 
@@ -46,7 +46,7 @@ codecvt_null<wchar_t>::do_out(
     return std::codecvt_base::ok;
 }
 
-BOOST_WARCHIVE_DECL BOOST_DLLEXPORT std::codecvt_base::result
+BOOST_WARCHIVE_DECL std::codecvt_base::result
 codecvt_null<wchar_t>::do_in(
     std::mbstate_t & /*state*/,
     const char * first1, 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -133,7 +133,7 @@ test-suite "serialization" :
 
 if ! $(BOOST_ARCHIVE_LIST) {
     test-suite "serialization2" : 
-        [ test-bsl-run-no-lib test_inclusion ]
+        [ test-bsl-run test_inclusion ]
         [ test-bsl-run test_dll_exported : : dll_polymorphic_derived2_lib ]
         [ test-bsl-run test_dll_simple : : dll_a_lib ]
         [ compile test_dll_plugin.cpp ]


### PR DESCRIPTION
I was not able to build boostorg/uuid in appveyor with the develop branch of serialization nor with the master branch of serialization, I ran into issues 12205, 12450, 12741.

This pull request has fixes for codecvt_null<wchar_t> and singleton_module::get_lock undefined at link time - these fixes allowed me to build boostorg/uuid on appveyor and travis ci properly, and may address trac items 12205, 12450, 12741

Example of a failing job:

https://ci.appveyor.com/project/jeking3/uuid/build/1.0.6-develop/job/otocinjh2pu7xbun

A more complete Appveyor build showing the build of serialization on appveyor with a variety of compilers - I decided to decouple the appveyor and travis upgrades from these code fixes for this submission into serialization however:

https://ci.appveyor.com/project/jeking3/serialization

Finally, here's a build job on Appveyor with these changed patched in, it looks like there are still mingw issues in serialization:

https://ci.appveyor.com/project/jeking3/uuid/build/1.0.10-develop