### PR TITLE
Avoid dereferencing a nullptr in save_pointer_type::register_type

### DIFF
--- a/include/boost/archive/detail/oserializer.hpp
+++ b/include/boost/archive/detail/oserializer.hpp
@@ -338,7 +338,7 @@ struct save_pointer_type {
     };
 
     template<class T>
-    static const basic_pointer_oserializer * register_type(Archive &ar, T & /*t*/){
+    static const basic_pointer_oserializer * register_type(Archive &ar, T* const /*t*/){
         // there should never be any need to save an abstract polymorphic 
         // class pointer.  Inhibiting code generation for this
         // permits abstract base classes to be used - note: exception
@@ -405,7 +405,7 @@ struct save_pointer_type {
             // if its not a pointer to a more derived type
             const void *vp = static_cast<const void *>(&t);
             if(*this_type == *true_type){
-                const basic_pointer_oserializer * bpos = register_type(ar, t);
+                const basic_pointer_oserializer * bpos = register_type(ar, &t);
                 ar.save_pointer(vp, bpos);
                 return;
             }
@@ -464,7 +464,7 @@ struct save_pointer_type {
 
     template<class TPtr>
     static void invoke(Archive &ar, const TPtr t){
-        register_type(ar, * t);
+        register_type(ar, t);
         if(NULL == t){
             basic_oarchive & boa 
                 = boost::serialization::smart_cast_reference<basic_oarchive &>(ar);


### PR DESCRIPTION
Currently, `save_pointer_type::register_type` possibly dereferences a `nullptr` but uses the value only for type deduction. This causes problems when serializing a `nullptr` with `clang-5`. In particular, the subsequent check (in line 468) is skipped and `save(ar, * t)` (in line 475) is executed.

We can fix this by expecting a pointer type in `register_type` instead of a reference.