### PR TITLE
Add missing include file in test_slist_ptrs

### DIFF
--- a/test/test_slist_ptrs.cpp
+++ b/test/test_slist_ptrs.cpp
@@ -27,6 +27,7 @@ namespace std{
 #include "test_tools.hpp"
 
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/list.hpp>
 
 #include "A.hpp"
 #include "A.ipp"


### PR DESCRIPTION
The test tries to serialize a list so `serialization/list.hpp` should be included.