### PR TITLE
Fix some memory leaks in tests

### DIFF
--- a/test/test_cyclic_ptrs.cpp
+++ b/test/test_cyclic_ptrs.cpp
@@ -143,6 +143,7 @@ int test2(){
         ia >> BOOST_SERIALIZATION_NVP(j2);
     }
     BOOST_CHECK(*j1 == *j2);
+    delete j1;
     BOOST_CHECK(j2 == j2->j);
     std::remove(testfile);
     return EXIT_SUCCESS;

--- a/test/test_derived_class_ptr.cpp
+++ b/test/test_derived_class_ptr.cpp
@@ -44,6 +44,7 @@ int test_main( int /* argc */, char* /* argv */[] )
     }
     BOOST_CHECK(tb != tb1);
     BOOST_CHECK(*tb == *tb1);
+    delete tb;
     std::remove(testfile);
     return EXIT_SUCCESS;
 }

--- a/test/test_diamond.cpp
+++ b/test/test_diamond.cpp
@@ -198,6 +198,7 @@ test_main( int /* argc */, char* /* argv */[] )
     BOOST_CHECK(1 == save_count);
     BOOST_CHECK(1 == load_count);
     BOOST_CHECK(*bp2 == *bp);
+    delete bp;
     std::remove(testfile);
 
     return EXIT_SUCCESS;

--- a/test/test_dll_exported.cpp
+++ b/test/test_dll_exported.cpp
@@ -87,6 +87,7 @@ void save_exported(const char *testfile)
 
     delete rb1;
     delete rb2;
+    delete rd21;
 }
 
 // save exported polymorphic class

--- a/test/test_mult_archive_types.cpp
+++ b/test/test_mult_archive_types.cpp
@@ -117,5 +117,8 @@ int test_main(int /* argc */, char * /* argv */[])
     // Try to save and load pointers to Bs, to an xml archive
     test_save_and_load<xml_oarchive, xml_iarchive>(b, b1);
 
+    delete a;
+    delete b;
+
     return EXIT_SUCCESS;
 }

--- a/test/test_simple_class_ptr.cpp
+++ b/test/test_simple_class_ptr.cpp
@@ -45,6 +45,7 @@ int test_main( int /* argc */, char* /* argv */[] )
     }
     BOOST_CHECK(ta != ta1);
     BOOST_CHECK(*ta == *ta1);
+    delete ta;
     std::remove(testfile);
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
All these tests simply miss to call `delete` for memory allocated with `new`.