### PR TITLE
Avoid dereferencing a nullptr

### DIFF
--- a/include/boost/archive/detail/iserializer.hpp
+++ b/include/boost/archive/detail/iserializer.hpp
@@ -483,7 +483,7 @@ struct load_pointer_type {
     };
 
     template<class T>
-    static const basic_pointer_iserializer * register_type(Archive &ar, const T & /*t*/){
+    static const basic_pointer_iserializer * register_type(Archive &ar, const T* const /*t*/){
         // there should never be any need to load an abstract polymorphic 
         // class pointer.  Inhibiting code generation for this
         // permits abstract base classes to be used - note: exception
@@ -522,7 +522,7 @@ struct load_pointer_type {
     }
 
     template<class T>
-    static void check_load(T & /* t */){
+    static void check_load(T * const /* t */){
         check_pointer_level< T >();
         check_pointer_tracking< T >();
     }
@@ -536,8 +536,8 @@ struct load_pointer_type {
 
     template<class Tptr>
     static void invoke(Archive & ar, Tptr & t){
-        check_load(*t);
-        const basic_pointer_iserializer * bpis_ptr = register_type(ar, *t);
+        check_load(t);
+        const basic_pointer_iserializer * bpis_ptr = register_type(ar, t);
         const basic_pointer_iserializer * newbpis_ptr = ar.load_pointer(
             // note major hack here !!!
             // I tried every way to convert Tptr &t (where Tptr might


### PR DESCRIPTION
This is similar to #62. Again, changing the signature avoids the need to dereference a `nullptr`.