### PR TITLE
Improve appveyor setup for MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,6 +53,7 @@ install:
   - git submodule init libs/unordered
   - git submodule init libs/utility
   - git submodule init libs/variant
+  - git submodule init libs/winapi
   - git submodule init tools/build
   - git submodule update
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\serialization


### PR DESCRIPTION
As can be seen in https://ci.appveyor.com/project/RobertRamey/serialization-5b0xm/build/1.0.92-develop for example, we are missing to include `winapi`.