### PR TITLE
replace uncaught_exception with uncaught_exceptions

### DIFF
--- a/include/boost/archive/impl/basic_text_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_oprimitive.ipp
@@ -8,6 +8,12 @@
 
 //  See http://www.boost.org for updates, documentation, and revision history.
 
+#if __cplusplus > 201402 || (defined(_MSVC_LANG) && _MSVC_LANG > 201402)
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exceptions()
+#else
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exception()
+#endif
+
 #include <cstddef> // NULL
 #include <algorithm> // std::copy
 #include <exception> // std::uncaught_exception
@@ -106,7 +112,7 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
 template<class OStream>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL
 basic_text_oprimitive<OStream>::~basic_text_oprimitive(){
-    if(std::uncaught_exception())
+    if(BOOST_ARCHIVE_UNCAUGHT_EXCEPTION())
         return;
     os << std::endl;
 }

--- a/include/boost/archive/impl/xml_iarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_iarchive_impl.ipp
@@ -8,6 +8,12 @@
 
 //  See http://www.boost.org for updates, documentation, and revision history.
 
+#if __cplusplus > 201402 || (defined(_MSVC_LANG) && _MSVC_LANG > 201402)
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exceptions()
+#else
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exception()
+#endif
+
 #include <boost/config.hpp>
 #include <cstring> // memcpy
 #include <cstddef> // NULL
@@ -189,7 +195,7 @@ xml_iarchive_impl<Archive>::xml_iarchive_impl(
 template<class Archive>
 BOOST_ARCHIVE_DECL
 xml_iarchive_impl<Archive>::~xml_iarchive_impl(){
-    if(std::uncaught_exception())
+    if(BOOST_ARCHIVE_UNCAUGHT_EXCEPTION())
         return;
     if(0 == (this->get_flags() & no_header)){
         gimpl->windup(is);

--- a/include/boost/archive/impl/xml_oarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_oarchive_impl.ipp
@@ -6,6 +6,12 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#if __cplusplus > 201402 || (defined(_MSVC_LANG) && _MSVC_LANG > 201402)
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exceptions()
+#else
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exception()
+#endif
+
 #include <ostream>
 #include <iomanip>
 #include <algorithm> // std::copy
@@ -132,7 +138,7 @@ xml_oarchive_impl<Archive>::save_binary(const void *address, std::size_t count){
 template<class Archive>
 BOOST_ARCHIVE_DECL
 xml_oarchive_impl<Archive>::~xml_oarchive_impl(){
-    if(std::uncaught_exception())
+    if(BOOST_ARCHIVE_UNCAUGHT_EXCEPTION())
         return;
     if(0 == (this->get_flags() & no_header))
         this->windup();

--- a/include/boost/archive/impl/xml_wiarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_wiarchive_impl.ipp
@@ -8,6 +8,12 @@
 
 //  See http://www.boost.org for updates, documentation, and revision history.
 
+#if __cplusplus > 201402 || (defined(_MSVC_LANG) && _MSVC_LANG > 201402)
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exceptions()
+#else
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exception()
+#endif
+
 #include <cstring>
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{ 
@@ -176,7 +182,7 @@ xml_wiarchive_impl<Archive>::xml_wiarchive_impl(
 template<class Archive>
 BOOST_WARCHIVE_DECL
 xml_wiarchive_impl<Archive>::~xml_wiarchive_impl(){
-    if(std::uncaught_exception())
+    if(BOOST_ARCHIVE_UNCAUGHT_EXCEPTION())
         return;
     if(0 == (this->get_flags() & no_header)){
         gimpl->windup(is);

--- a/include/boost/archive/impl/xml_woarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_woarchive_impl.ipp
@@ -6,6 +6,12 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+#if __cplusplus > 201402 || (defined(_MSVC_LANG) && _MSVC_LANG > 201402)
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exceptions()
+#else
+# define BOOST_ARCHIVE_UNCAUGHT_EXCEPTION() std::uncaught_exception()
+#endif
+
 #include <boost/config.hpp>
 #ifndef BOOST_NO_STD_WSTREAMBUF
 
@@ -139,7 +145,7 @@ xml_woarchive_impl<Archive>::xml_woarchive_impl(
 template<class Archive>
 BOOST_WARCHIVE_DECL
 xml_woarchive_impl<Archive>::~xml_woarchive_impl(){
-    if(std::uncaught_exception())
+    if(BOOST_ARCHIVE_UNCAUGHT_EXCEPTION())
         return;
     if(0 == (this->get_flags() & no_header)){
         os << L"</boost_serialization>";


### PR DESCRIPTION
The former is deprecated in C++17 and replaced by the latter.

Signed-off-by: Daniela Engert <dani@ngrt.de>