### PR TITLE
trac-9882: fix -Wshadow errors in serialization (seen during date_time build)

### DIFF
--- a/include/boost/archive/xml_iarchive.hpp
+++ b/include/boost/archive/xml_iarchive.hpp
@@ -123,8 +123,8 @@ namespace archive {
 class BOOST_SYMBOL_VISIBLE xml_iarchive : 
     public xml_iarchive_impl<xml_iarchive>{
 public:
-    xml_iarchive(std::istream & is, unsigned int flags = 0) :
-        xml_iarchive_impl<xml_iarchive>(is, flags)
+    xml_iarchive(std::istream & _is, unsigned int flags = 0) :
+        xml_iarchive_impl<xml_iarchive>(_is, flags)
     {}
     ~xml_iarchive(){};
 };

--- a/include/boost/archive/xml_oarchive.hpp
+++ b/include/boost/archive/xml_oarchive.hpp
@@ -118,8 +118,8 @@ class BOOST_SYMBOL_VISIBLE xml_oarchive :
     public xml_oarchive_impl<xml_oarchive>
 {
 public:
-    xml_oarchive(std::ostream & os, unsigned int flags = 0) :
-        xml_oarchive_impl<xml_oarchive>(os, flags)
+    xml_oarchive(std::ostream & _os, unsigned int flags = 0) :
+        xml_oarchive_impl<xml_oarchive>(_os, flags)
     {}
     ~xml_oarchive(){}
 };


### PR DESCRIPTION
https://svn.boost.org/trac10/ticket/9882