### PR TITLE
Fix MinGW ICE

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - git submodule init libs/concept_check
   - git submodule init libs/config
   - git submodule init libs/container
+  - git submodule init libs/container_hash
   - git submodule init libs/core
   - git submodule init libs/detail
   - git submodule init libs/filesystem

--- a/include/boost/serialization/void_cast.hpp
+++ b/include/boost/serialization/void_cast.hpp
@@ -181,13 +181,14 @@ void_caster_primitive<Derived, Base>::void_caster_primitive() :
     void_caster( 
         & type_info_implementation<Derived>::type::get_const_instance(), 
         & type_info_implementation<Base>::type::get_const_instance(),
-        // note:I wanted to displace from 0 here, but at least one compiler
-        // treated 0 by not shifting it at all.
+        /* note about displacement:
+         * displace 0: at least one compiler treated 0 by not shifting it at all
+         * displace by small value (8): caused ICE on certain mingw gcc versions */
         reinterpret_cast<std::ptrdiff_t>(
             static_cast<Derived *>(
-                reinterpret_cast<Base *>(8)
+                reinterpret_cast<Base *>(1 << 20)
             )
-        ) - 8
+        ) - (1 << 20)
     )
 {
     recursive_register();


### PR DESCRIPTION
Just fiddling with the displacement is apparently enough to avoid triggering the ICE on MinGW.

(Note: Superset of #90)