### PR TITLE
Fix gcc 8 warning.

### DIFF
--- a/include/boost/archive/text_oarchive.hpp
+++ b/include/boost/archive/text_oarchive.hpp
@@ -65,10 +65,10 @@ protected:
         basic_text_oprimitive<std::ostream>::save(t);
     }
     void save(const version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     void save(const boost::serialization::item_version_type & t){
-        save(static_cast<const unsigned int>(t));
+        save(static_cast<unsigned int>(t));
     }
     BOOST_ARCHIVE_DECL void 
     save(const char * t);


### PR DESCRIPTION
Hi,

This fixes a very simple warning that gcc 8 throws with -Wall -Wextra -Werror:
In file included from /data3/mwrep/rgeissler/SI/br_5-1.wk2/common/include/si/common/HTHSegmentationCacheInfoSerialization.h:20,
                 from src/SEI_DUCommandGetInfoHTHSegmentationCacheExec.cpp:16:
/remote/mw/combld/delivery/pack18.continuous/components.osp/osp/Boost/18-0-0-0/include/boost/archive/text_oarchive.hpp: In member function ‘void boost::archive::text_oarchive_impl<Archive>::save(const boost::archive::version_type&)’: 
/remote/mw/combld/delivery/pack18.continuous/components.osp/osp/Boost/18-0-0-0/include/boost/archive/text_oarchive.hpp:68:47: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers] 
         save(static_cast<const unsigned int>(t));
                                               ^
/remote/mw/combld/delivery/pack18.continuous/components.osp/osp/Boost/18-0-0-0/include/boost/archive/text_oarchive.hpp: In member function ‘void boost::archive::text_oarchive_impl<Archive>::save(const boost::serialization::item_version_type&)’:    
/remote/mw/combld/delivery/pack18.continuous/components.osp/osp/Boost/18-0-0-0/include/boost/archive/text_oarchive.hpp:71:47: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers] 
         save(static_cast<const unsigned int>(t));
                                               ^

Cheers,
Romain