### PR TITLE
Fix object tracking for variant

### DIFF
--- a/include/boost/archive/detail/basic_iarchive.hpp
+++ b/include/boost/archive/detail/basic_iarchive.hpp
@@ -96,6 +96,15 @@ public:
     delete_created_pointers();
 };
 
+template<typename Archive>
+inline void reset_object_address(
+    Archive& ar,
+    const void * new_address,
+    const void * old_address
+){
+    ar.reset_object_address(new_address, old_address);
+}
+    
 } // namespace detail
 } // namespace archive
 } // namespace boost

--- a/include/boost/serialization/archive_input_unordered_map.hpp
+++ b/include/boost/serialization/archive_input_unordered_map.hpp
@@ -46,7 +46,8 @@ struct archive_input_unordered_map
         // in the archive.  This is the usual case, but here there is no way
         // to determine that.  
         if(result.second){
-            ar.reset_object_address(
+            reset_object_address(
+                ar,
                 & (result.first->second),
                 & t.reference().second
             );
@@ -71,7 +72,8 @@ struct archive_input_unordered_multimap
         // note: the following presumes that the map::value_type was NOT tracked
         // in the archive.  This is the usual case, but here there is no way
         // to determine that.  
-        ar.reset_object_address(
+        reset_object_address(
+            ar,
             & result->second,
             & t.reference()
         );

--- a/include/boost/serialization/archive_input_unordered_set.hpp
+++ b/include/boost/serialization/archive_input_unordered_set.hpp
@@ -43,7 +43,7 @@ struct archive_input_unordered_set
         std::pair<typename Container::const_iterator, bool> result = 
             s.insert(boost::move(t.reference()));
         if(result.second)
-            ar.reset_object_address(& (* result.first), & t.reference());
+            reset_object_address(ar, & (* result.first), & t.reference());
     }
 };
 
@@ -61,7 +61,7 @@ struct archive_input_unordered_multiset
         ar >> boost::serialization::make_nvp("item", t.reference());
         typename Container::const_iterator result =
             s.insert(boost::move(t.reference()));
-        ar.reset_object_address(& (* result), & t.reference());
+        reset_object_address(ar, & (* result), & t.reference());
     }
 };
 

--- a/include/boost/serialization/map.hpp
+++ b/include/boost/serialization/map.hpp
@@ -61,7 +61,7 @@ inline void load_map_collection(Archive & ar, Container &s)
         ar >> boost::serialization::make_nvp("item", t.reference());
         typename Container::iterator result =
             s.insert(hint, boost::move(t.reference()));
-        ar.reset_object_address(& (result->second), & t.reference().second);
+        reset_object_address(ar, & (result->second), & t.reference().second);
         hint = result;
         ++hint;
     }

--- a/include/boost/serialization/set.hpp
+++ b/include/boost/serialization/set.hpp
@@ -57,7 +57,7 @@ inline void load_set_collection(Archive & ar, Container &s)
         ar >> boost::serialization::make_nvp("item", t.reference());
         typename Container::iterator result =
             s.insert(hint, boost::move(t.reference()));
-        ar.reset_object_address(& (* result), & t.reference());
+        reset_object_address(ar, & (* result), & t.reference());
         hint = result;
     }
 }

--- a/include/boost/serialization/variant.hpp
+++ b/include/boost/serialization/variant.hpp
@@ -22,6 +22,8 @@
 // thanks to Robert Ramey, Peter Dimov, and Richard Crossley.
 //
 
+#include <boost/assert.hpp>
+
 #include <boost/mpl/front.hpp>
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/eval_if.hpp>
@@ -73,55 +75,102 @@ void save(
 template<class S>
 struct variant_impl {
 
-    struct load_null {
-        template<class Archive, class V>
+    struct action_null {
+        template<class Archive, class V, class F>
         static void invoke(
             Archive & /*ar*/,
             int /*which*/,
             V & /*v*/,
-            const unsigned int /*version*/
+            F /*f*/
         ){}
     };
 
-    struct load_impl {
-        template<class Archive, class V>
+    struct action_impl {
+        template<class Archive, class V, class F>
         static void invoke(
             Archive & ar,
             int which,
             V & v,
-            const unsigned int version
+            F f
         ){
             if(which == 0){
-                // note: A non-intrusive implementation (such as this one)
-                // necessary has to copy the value.  This wouldn't be necessary
-                // with an implementation that de-serialized to the address of the
-                // aligned storage included in the variant.
                 typedef typename mpl::front<S>::type head_type;
-                head_type value;
-                ar >> BOOST_SERIALIZATION_NVP(value);
-                v = value;
-                ar.reset_object_address(& boost::get<head_type>(v), & value);
+                f.template operator()<head_type>(ar, v);
                 return;
             }
             typedef typename mpl::pop_front<S>::type type;
-            variant_impl<type>::load(ar, which - 1, v, version);
+            variant_impl<type>::action(ar, which - 1, v, f);
         }
     };
 
-    template<class Archive, class V>
-    static void load(
+    template<class Archive, class V, class F>
+    static void action(
         Archive & ar,
         int which,
         V & v,
-        const unsigned int version
+        F f
     ){
         typedef typename mpl::eval_if<mpl::empty<S>,
-            mpl::identity<load_null>,
-            mpl::identity<load_impl>
+            mpl::identity<action_null>,
+            mpl::identity<action_impl>
         >::type typex;
-        typex::invoke(ar, which, v, version);
+        typex::invoke(ar, which, v, f);
     }
 
+};
+
+} // namespace serialization
+    
+namespace archive {
+namespace detail {
+        
+    template<typename VFrom>
+    struct reset_variant_content_address
+    {
+        const VFrom* vfrom;
+        template<typename T, typename Archive, typename V>
+        void operator()(Archive & ar, V & v) const {
+            ar.reset_object_address(& boost::get<T>(v), boost::get<T>(vfrom));
+        }
+    };
+        
+    template<typename Archive,
+             BOOST_VARIANT_ENUM_PARAMS(/* typename */ class T)>
+    inline void reset_object_address(
+        Archive & ar,
+        const boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> * new_address,
+        const boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)> * old_address
+    ){
+        ar.reset_object_address(new_address, old_address);
+        typedef typename boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>::types
+            types;
+        BOOST_ASSERT(new_address->which() == old_address->which());
+        serialization::variant_impl<types>::action
+            (ar, new_address->which(), *new_address,
+             reset_variant_content_address
+             <boost::variant<BOOST_VARIANT_ENUM_PARAMS(T)>>
+             {old_address});
+    }
+    
+} // namespace detail
+} // namespace archive
+
+namespace serialization {    
+
+struct assign_to_variant
+{
+    template<typename T, typename Archive, typename V>
+    void operator()(Archive & ar, V & v) const
+    {
+        // note: A non-intrusive implementation (such as this one)
+        // necessary has to copy the value.  This wouldn't be necessary
+        // with an implementation that de-serialized to the address of the
+        // aligned storage included in the variant.
+        T value;
+        ar >> BOOST_SERIALIZATION_NVP(value);
+        v = value;
+        ar.reset_object_address(& boost::get<T>(v), & value);
+    }
 };
 
 template<class Archive, BOOST_VARIANT_ENUM_PARAMS(/* typename */ class T)>
@@ -140,7 +189,7 @@ void load(
                 boost::archive::archive_exception::unsupported_version
             )
         );
-    variant_impl<types>::load(ar, which, v, version);
+    variant_impl<types>::action(ar, which, v, assign_to_variant{});
 }
 
 template<class Archive,BOOST_VARIANT_ENUM_PARAMS(/* typename */ class T)>

--- a/test/test_reset_object_address.cpp
+++ b/test/test_reset_object_address.cpp
@@ -26,8 +26,18 @@ namespace std{
 #include <boost/archive/polymorphic_text_oarchive.hpp>
 #include <boost/archive/polymorphic_text_iarchive.hpp>
 
+#include "boost/functional/hash/hash.hpp"
+
 #include <boost/serialization/list.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/set.hpp>
+#include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/unordered_set.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/variant.hpp>
+
+#include <boost/variant.hpp>
+#include <boost/variant/get.hpp>
 
 // Someday, maybe all tests will be converted to the unit test framework.
 // but for now use the text execution monitor to be consistent with all
@@ -398,6 +408,137 @@ void test8(){
     }
 }
 
+struct H {
+    int i;
+    template<class Archive>
+    void serialize(Archive &ar, const unsigned int /*file_version*/){
+        ar & i;
+    }
+    bool operator==(const H & rhs) const {
+        return i == rhs.i;
+    }
+};
+
+inline bool operator<(const H & lhs, const H & rhs) {
+    return lhs.i < rhs.i;
+}
+
+inline std::size_t hash_value(H const & val) {
+    return val.i;
+}
+
+// test a pointer to an object contained into a variant that is an
+// element of a map
+void test9()
+{
+    std::stringstream ss;
+    H const h{5};
+    typedef boost::variant<H, int> variant_t;
+    typedef std::map<int, variant_t> map_t;
+    H const * h_ptr;
+    {
+        map_t map;
+        variant_t v{h};
+        map[0] = v;
+        h_ptr = boost::strict_get<H const>(&map[0]);
+        boost::archive::text_oarchive oa(ss);
+        oa << map;
+        oa << h_ptr;
+    }
+    H * h1_ptr;
+    {
+        map_t map;
+        boost::archive::text_iarchive ia(ss);
+        ia >> map;
+        ia >> h1_ptr;
+    }
+    BOOST_CHECK_EQUAL(*h1_ptr, h);
+}
+
+// test a pointer to an object contained into a variant that is an
+// element of a unordered_map
+void test10()
+{
+    std::stringstream ss;
+    H const h{5};
+    typedef boost::variant<H, int> variant_t;
+    typedef std::unordered_map<int, variant_t> umap_t;
+    H const * h_ptr;
+    {
+        umap_t map;
+        variant_t v{h};
+        map[0] = v;
+        h_ptr = boost::strict_get<H const>(&map[0]);
+        boost::archive::text_oarchive oa(ss);
+        oa << map;
+        oa << h_ptr;
+    }
+    H * h1_ptr;
+    {
+        umap_t map;
+        boost::archive::text_iarchive ia(ss);
+        ia >> map;
+        ia >> h1_ptr;
+    }
+    BOOST_CHECK_EQUAL(*h1_ptr, h);
+}
+
+// test a pointer to an object contained into a variant that is an
+// element of a unoredered_set
+void test11()
+{
+    std::stringstream ss;
+    H const h{5};
+    typedef boost::variant<H, int> variant_t;
+    typedef std::unordered_set<variant_t, boost::hash<variant_t>> uset_t;
+    H const * h_ptr;
+    {
+        uset_t set;
+        variant_t v{h};
+        set.insert(v);
+        h_ptr = boost::strict_get<H const>(&(*set.begin()));
+        boost::archive::text_oarchive oa(ss);
+        oa << set;
+        oa << h_ptr;
+    }
+    H * h1_ptr;
+    {
+        uset_t set;
+        boost::archive::text_iarchive ia(ss);
+        ia >> set;
+        ia >> h1_ptr;
+    }
+    BOOST_CHECK_EQUAL(*h1_ptr, h);
+}
+
+// test a pointer to an object contained into a variant that is an
+// element of a set
+void test12()
+{
+    std::stringstream ss;
+    H const h{5};
+    typedef boost::variant<H, int> variant_t;
+    typedef std::set<variant_t> uset_t;
+    H const * h_ptr;
+    {
+        uset_t set;
+        variant_t v{h};
+        set.insert(v);
+        h_ptr = boost::strict_get<H const>(&(*set.begin()));
+        boost::archive::text_oarchive oa(ss);
+        oa << set;
+        oa << h_ptr;
+    }
+    H * h1_ptr;
+    {
+        uset_t set;
+        boost::archive::text_iarchive ia(ss);
+        ia >> set;
+        ia >> h1_ptr;
+    }
+    BOOST_CHECK_EQUAL(*h1_ptr, h);
+}
+
 int test_main(int /* argc */, char * /* argv */[])
 {
     test1();
@@ -408,5 +549,9 @@ int test_main(int /* argc */, char * /* argv */[])
     test6();
     test7();
     test8();
+    test9();
+    test10();
+    test11();
+    test12();
     return EXIT_SUCCESS;
 }

--- a/test/test_reset_object_address.cpp
+++ b/test/test_reset_object_address.cpp
@@ -31,8 +31,6 @@ namespace std{
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/set.hpp>
-#include <boost/serialization/unordered_map.hpp>
-#include <boost/serialization/unordered_set.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/variant.hpp>
 
@@ -455,65 +453,10 @@ void test9()
     BOOST_CHECK_EQUAL(*h1_ptr, h);
 }
 
-// test a pointer to an object contained into a variant that is an
-// element of a unordered_map
-void test10()
-{
-    std::stringstream ss;
-    H const h{5};
-    typedef boost::variant<H, int> variant_t;
-    typedef std::unordered_map<int, variant_t> umap_t;
-    H const * h_ptr;
-    {
-        umap_t map;
-        variant_t v{h};
-        map[0] = v;
-        h_ptr = boost::strict_get<H const>(&map[0]);
-        boost::archive::text_oarchive oa(ss);
-        oa << map;
-        oa << h_ptr;
-    }
-    H * h1_ptr;
-    {
-        umap_t map;
-        boost::archive::text_iarchive ia(ss);
-        ia >> map;
-        ia >> h1_ptr;
-    }
-    BOOST_CHECK_EQUAL(*h1_ptr, h);
-}
-
-// test a pointer to an object contained into a variant that is an
-// element of a unoredered_set
-void test11()
-{
-    std::stringstream ss;
-    H const h{5};
-    typedef boost::variant<H, int> variant_t;
-    typedef std::unordered_set<variant_t, boost::hash<variant_t>> uset_t;
-    H const * h_ptr;
-    {
-        uset_t set;
-        variant_t v{h};
-        set.insert(v);
-        h_ptr = boost::strict_get<H const>(&(*set.begin()));
-        boost::archive::text_oarchive oa(ss);
-        oa << set;
-        oa << h_ptr;
-    }
-    H * h1_ptr;
-    {
-        uset_t set;
-        boost::archive::text_iarchive ia(ss);
-        ia >> set;
-        ia >> h1_ptr;
-    }
-    BOOST_CHECK_EQUAL(*h1_ptr, h);
-}
 
 // test a pointer to an object contained into a variant that is an
 // element of a set
-void test12()
+void test10()
 {
     std::stringstream ss;
     H const h{5};
@@ -551,7 +494,5 @@ int test_main(int /* argc */, char * /* argv */[])
     test8();
     test9();
     test10();
-    test11();
-    test12();
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fix object tracking for a pointer to an object contained into a variant that is an element of a container which loads a `value_type` into a local object. For example a `std::map` with a `boost::variant` as a `mapped_type`.

This commit supports:
- map
- multimap
- unordered_map
- unordered_multimap
- set
- multiset
- unordered_set
- unordered_multiset