### PR TITLE
Fix object tracking for variant

### DIFF
--- a/include/boost/archive/detail/basic_iarchive.hpp
+++ b/include/boost/archive/detail/basic_iarchive.hpp
@@ -96,6 +96,15 @@ public:
     delete_created_pointers();
 };
 
+template<typename Archive>
+inline void reset_object_address(
+    Archive& ar,
+    const void * new_address,
+    const void * old_address
+){
+    ar.reset_object_address(new_address, old_address);
+}
+    
 } // namespace detail
 } // namespace archive
 } // namespace boost

--- a/include/boost/serialization/archive_input_unordered_map.hpp
+++ b/include/boost/serialization/archive_input_unordered_map.hpp
@@ -46,7 +46,8 @@ struct archive_input_unordered_map
         // in the archive.  This is the usual case, but here there is no way
         // to determine that.  
         if(result.second){
-            ar.reset_object_address(
+            reset_object_address(
+                ar,
                 & (result.first->second),
                 & t.reference().second
             );
@@ -71,7 +72,8 @@ struct archive_input_unordered_multimap
         // note: the following presumes that the map::value_type was NOT tracked
         // in the archive.  This is the usual case, but here there is no way
         // to determine that.  
-        ar.reset_object_address(
+        reset_object_address(
+            ar,
             & result->second,
             & t.reference()
         );

--- a/include/boost/serialization/archive_input_unordered_set.hpp
+++ b/include/boost/serialization/archive_input_unordered_set.hpp
@@ -43,7 +43,7 @@ struct archive_input_unordered_set
         std::pair<typename Container::const_iterator, bool> result = 
             s.insert(boost::move(t.reference()));
         if(result.second)
-            ar.reset_object_address(& (* result.first), & t.reference());
+            reset_object_address(ar, & (* result.first), & t.reference());
     }
 };
 
@@ -61,7 +61,7 @@ struct archive_input_unordered_multiset
         ar >> boost::serialization::make_nvp("item", t.reference());
         typename Container::const_iterator result =
             s.insert(boost::move(t.reference()));
-        ar.reset_object_address(& (* result), & t.reference());
+        reset_object_address(ar, & (* result), & t.reference());
     }
 };
 

--- a/include/boost/serialization/map.hpp
+++ b/include/boost/serialization/map.hpp
@@ -61,7 +61,7 @@ inline void load_map_collection(Archive & ar, Container &s)
         ar >> boost::serialization::make_nvp("item", t.reference());
         typename Container::iterator result =
             s.insert(hint, boost::move(t.reference()));
-        ar.reset_object_address(& (result->second), & t.reference().second);
+        reset_object_address(ar, & (result->second), & t.reference().second);
         hint = result;
         ++hint;
     }

--- a/include/boost/serialization/set.hpp
+++ b/include/boost/serialization/set.hpp
@@ -57,7 +57,7 @@ inline void load_set_collection(Archive & ar, Container &s)
         ar >> boost::serialization::make_nvp("item", t.reference());
         typename Container::iterator result =
             s.insert(hint, boost::move(t.reference()));
-        ar.reset_object_address(& (* result), & t.reference());
+        reset_object_address(ar, & (* result), & t.reference());
         hint = result;
     }
 }

--- a/test/test_reset_object_address.cpp
+++ b/test/test_reset_object_address.cpp
@@ -26,8 +26,16 @@ namespace std{
 #include <boost/archive/polymorphic_text_oarchive.hpp>
 #include <boost/archive/polymorphic_text_iarchive.hpp>
 
+#include "boost/functional/hash/hash.hpp"
+
 #include <boost/serialization/list.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/set.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/variant.hpp>
+
+#include <boost/variant.hpp>
+#include <boost/variant/get.hpp>
 
 // Someday, maybe all tests will be converted to the unit test framework.
 // but for now use the text execution monitor to be consistent with all
@@ -398,6 +406,94 @@ void test8(){
     }
 }
 
+struct H {
+    int i;
+};
+
+namespace boost {
+namespace serialization {
+        
+template<class Archive>
+void serialize(Archive &ar, H & h, const unsigned int /*file_version*/){
+    ar & h.i;
+}
+
+} // namespace serialization
+} // namespace boost
+
+inline bool operator==(H const & lhs, H const & rhs) {
+    return lhs.i == rhs.i;
+}
+
+inline bool operator!=(H const & lhs, H const & rhs) {
+    return !(lhs == rhs);
+}
+
+inline bool operator<(H const & lhs, H const & rhs) {
+    return lhs.i < rhs.i;
+}
+
+inline std::size_t hash_value(H const & val) {
+    return val.i;
+}
+
+// test a pointer to an object contained into a variant that is an
+// element of a map
+void test9()
+{
+    std::stringstream ss;
+    H const h = {5};
+    typedef boost::variant<H, int> variant_t;
+    typedef std::map<int, variant_t> map_t;
+    H const * h_ptr;
+    {
+        map_t map;
+        variant_t v(h);
+        map[0] = v;
+        h_ptr = boost::strict_get<H const>(&map[0]);
+        boost::archive::text_oarchive oa(ss);
+        oa << map;
+        oa << h_ptr;
+    }
+    H * h1_ptr;
+    {
+        map_t map;
+        boost::archive::text_iarchive ia(ss);
+        ia >> map;
+        ia >> h1_ptr;
+        BOOST_CHECK_EQUAL(*h1_ptr, h);
+    }
+}
+
+
+// test a pointer to an object contained into a variant that is an
+// element of a set
+void test10()
+{
+    std::stringstream ss;
+    H const h = {5};
+    typedef boost::variant<H, int> variant_t;
+    typedef std::set<variant_t> uset_t;
+    H const * h_ptr;
+    {
+        uset_t set;
+        variant_t v(h);
+        set.insert(v);
+        h_ptr = boost::strict_get<H const>(&(*set.begin()));
+        boost::archive::text_oarchive oa(ss);
+        oa << set;
+        oa << h_ptr;
+    }
+    H * h1_ptr;
+    {
+        uset_t set;
+        boost::archive::text_iarchive ia(ss);
+        ia >> set;
+        ia >> h1_ptr;
+        BOOST_CHECK_EQUAL(*h1_ptr, h);
+    }
+}
+
 int test_main(int /* argc */, char * /* argv */[])
 {
     test1();
@@ -408,5 +504,7 @@ int test_main(int /* argc */, char * /* argv */[])
     test6();
     test7();
     test8();
+    test9();
+    test10();
     return EXIT_SUCCESS;
 }

--- a/test/test_reset_object_address.cpp
+++ b/test/test_reset_object_address.cpp
@@ -445,23 +445,23 @@ void test9()
     H const h = {5};
     typedef boost::variant<H, int> variant_t;
     typedef std::map<int, variant_t> map_t;
-    H const * h_ptr;
+    map_t imap;
+    variant_t iv(h);
+    H const * ih_ptr;
     {
-        map_t map;
-        variant_t v(h);
-        map[0] = v;
-        h_ptr = boost::strict_get<H const>(&map[0]);
+        imap[0] = iv;
+        ih_ptr = boost::strict_get<H const>(&imap[0]);
         boost::archive::text_oarchive oa(ss);
-        oa << map;
-        oa << h_ptr;
+        oa << imap;
+        oa << ih_ptr;
     }
-    H * h1_ptr;
+    H * oh_ptr;
     {
-        map_t map;
+        map_t omap;
         boost::archive::text_iarchive ia(ss);
-        ia >> map;
-        ia >> h1_ptr;
-        BOOST_CHECK_EQUAL(*h1_ptr, h);
+        ia >> omap;
+        ia >> oh_ptr;
+        BOOST_CHECK_EQUAL(oh_ptr, boost::strict_get<H>(&omap[0]));
     }
 }
 
@@ -474,23 +474,23 @@ void test10()
     H const h = {5};
     typedef boost::variant<H, int> variant_t;
     typedef std::set<variant_t> uset_t;
-    H const * h_ptr;
+    uset_t iset;
+    variant_t iv(h);
+    H const * ih_ptr;
     {
-        uset_t set;
-        variant_t v(h);
-        set.insert(v);
-        h_ptr = boost::strict_get<H const>(&(*set.begin()));
+        iset.insert(iv);
+        ih_ptr = boost::strict_get<H const>(&(*iset.begin()));
         boost::archive::text_oarchive oa(ss);
-        oa << set;
-        oa << h_ptr;
+        oa << iset;
+        oa << ih_ptr;
     }
-    H * h1_ptr;
+    H * oh_ptr;
     {
-        uset_t set;
+        uset_t oset;
         boost::archive::text_iarchive ia(ss);
-        ia >> set;
-        ia >> h1_ptr;
-        BOOST_CHECK_EQUAL(*h1_ptr, h);
+        ia >> oset;
+        ia >> oh_ptr;
+        BOOST_CHECK_EQUAL(oh_ptr, boost::strict_get<H>(&(*oset.begin())));
     }
 }
 


### PR DESCRIPTION
Fix object tracking for a pointer to an object contained into a
variant that is an element of a container which loads the `value_type`
into a local object.

This commit supports:
- map
- multimap
- unordered_map
- unordered_multimap
- set
- multiset
- unordered_set
- unordered_multiset

Bugfix proposal for [#13456](https://svn.boost.org/trac10/ticket/13456)

A demo that illustrates the problem:
Online with C++11, gcc 7.2.0 and Boost 1.67.0: https://wandbox.org/permlink/7S016sfxGxHIQoJT

Package
[bug_serialization_variant_v2.tar.gz](https://github.com/boostorg/serialization/files/1964907/bug_serialization_variant_v2.tar.gz)
Build: `b2 -sBOOST_ROOT=<root_directory_of_boost>`
Run: `stage/demo`