### PR TITLE
Fix and test singleton implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ install:
   - ./b2 headers
 
 script:
-  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared} variant=${VARIANT}
+  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared} variant=${VARIANT} cxxflags=-fPIC cflags=-fPIC
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,20 @@ matrix:
   include:
     - os: linux
       compiler: g++
-      env: TOOLSET=gcc
+      env: TOOLSET=gcc VARIANT=debug
 
     - os: linux
+      compiler: g++
+      env: TOOLSET=gcc VARIANT=release
+
+    - os: linux
+      compiler: g++
+      env: TOOLSET=gcc LINK=static VARIANT=debug,release
+
+    - &linux_gcc5
+      os: linux
       compiler: g++-5
-      env: TOOLSET=gcc-5
+      env: TOOLSET=gcc-5 VARIANT=debug
       addons:
         apt:
           packages:
@@ -39,9 +48,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - os: linux
+    - <<: *linux_gcc5
+      env: TOOLSET=gcc-5 VARIANT=release
+
+    - <<: *linux_gcc5
+      env: TOOLSET=gcc-5 LINK=static VARIANT=debug,release
+
+    - &linux_gcc6
+      os: linux
       compiler: g++-6
-      env: TOOLSET=gcc-6
+      env: TOOLSET=gcc-6 VARIANT=debug
       addons:
         apt:
           packages:
@@ -49,9 +65,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - os: linux
+    - <<: *linux_gcc6
+      env: TOOLSET=gcc-6 VARIANT=release
+
+    - <<: *linux_gcc6
+      env: TOOLSET=gcc-6 LINK=static VARIANT=debug,release
+
+    - &linux_gcc7
+      os: linux
       compiler: g++-7
-      env: TOOLSET=gcc-7
+      env: TOOLSET=gcc-7 VARIANT=debug
       addons:
         apt:
           packages:
@@ -59,31 +82,35 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - os: linux
-      compiler: g++-7
-      env: TOOLSET=gcc-7 LINK=static
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
+    - <<: *linux_gcc7
+      env: TOOLSET=gcc-7 VARIANT=release
+
+    - <<: *linux_gcc7
+      env: TOOLSET=gcc-7 LINK=static VARIANT=debug,release
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang
+      env: TOOLSET=clang VARIANT=debug
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang LINK=static
+      env: TOOLSET=clang VARIANT=release
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang LINK=static VARIANT=debug,release
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang
+      env: TOOLSET=clang VARIANT=debug
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang LINK=static
+      env: TOOLSET=clang VARIANT=release
+
+    - os: osx
+      compiler: clang++
+      env: TOOLSET=clang LINK=static VARIANT=debug,release
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
@@ -99,7 +126,7 @@ install:
   - ./b2 headers
 
 script:
-  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared}
+  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared} variant=${VARIANT}
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ branches:
   only:
     - develop
 #    - master
+    - /feature\/.*/
 
 environment:
   matrix:
@@ -25,7 +26,9 @@ environment:
 
 install:
   - cd ..
-  - git clone -b %APPVEYOR_REPO_BRANCH%  https://github.com/boostorg/boost.git boost-root
+  - set BOOST_BRANCH=develop
+  - if "%APPVEYOR_REPO_BRANCH%"=="master" set BOOST_BRANCH=master
+  - git clone -b %BOOST_BRANCH%  https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule init libs/align
   - git submodule init libs/array

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cd ..
   - set BOOST_BRANCH=develop
   - if "%APPVEYOR_REPO_BRANCH%"=="master" set BOOST_BRANCH=master
-  - git clone -b %BOOST_BRANCH%  https://github.com/boostorg/boost.git boost-root
+  - git clone -b %BOOST_BRANCH% --depth=1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule init libs/align
   - git submodule init libs/array
@@ -80,4 +80,4 @@ build: off
 
 test_script:
   - cd libs/serialization/test
-  - b2 -j2 toolset=%BUILD_TOOLSET% link=%BUILD_LINK%
+  - b2 -j2 toolset=%BUILD_TOOLSET% link=%BUILD_LINK% variant=debug,release

--- a/include/boost/archive/impl/archive_serializer_map.ipp
+++ b/include/boost/archive/impl/archive_serializer_map.ipp
@@ -47,10 +47,6 @@ archive_serializer_map<Archive>::insert(const basic_serializer * bs){
 template<class Archive>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL void
 archive_serializer_map<Archive>::erase(const basic_serializer * bs){
-    BOOST_ASSERT(! boost::serialization::singleton<
-            extra_detail::map<Archive>
-        >::is_destroyed()
-    );
     if(boost::serialization::singleton<
         extra_detail::map<Archive>
     >::is_destroyed())

--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -121,20 +121,29 @@ namespace detail {
 // So there will only be one instance of this class. This does not hold
 // for singleton<T> as a class derived from singleton<T> could be
 // instantiated multiple times.
+// It also provides a flag `is_destroyed` which returns true, when the
+// class was destructed. It is static and hence accesible even after
+// destruction. This can be used to check, if the singleton is still
+// accesible e.g. in destructors of other singletons.
 template<class T>
 class singleton_wrapper : public T
 {
+    static bool & get_is_destroyed(){
+        // Prefer a static function member to avoid LNK1179.
+        // Note: As this is for a singleton (1 instance only) it must be set
+        // never be reset (to false)!
+        static bool is_destroyed_flag = false;
+        return is_destroyed_flag;
+    }
 public:
     singleton_wrapper(){
-        BOOST_ASSERT(!get_is_destroyed());
+        BOOST_ASSERT(!is_destroyed());
     }
     ~singleton_wrapper(){
         get_is_destroyed() = true;
     }
-    static bool & get_is_destroyed(){
-        // Prefer a static function member to avoid LNK1179. Note: Never reset!
-        static bool is_destroyed = false;
-        return is_destroyed;
+    static bool is_destroyed(){
+        return get_is_destroyed();
     }
 };
 
@@ -179,7 +188,7 @@ public:
         return get_instance();
     }
     BOOST_DLLEXPORT static bool is_destroyed(){
-        return detail::singleton_wrapper< T >::get_is_destroyed();
+        return detail::singleton_wrapper< T >::is_destroyed();
     }
 };
 

--- a/src/extended_type_info.cpp
+++ b/src/extended_type_info.cpp
@@ -125,7 +125,6 @@ BOOST_SERIALIZATION_DECL void
 extended_type_info::key_unregister() const{
     if(NULL == get_key())
         return;
-    BOOST_ASSERT(! singleton<detail::ktmap>::is_destroyed());
     if(! singleton<detail::ktmap>::is_destroyed()){
         detail::ktmap & x = singleton<detail::ktmap>::get_mutable_instance();
         detail::ktmap::iterator start = x.lower_bound(this);

--- a/src/extended_type_info_typeid.cpp
+++ b/src/extended_type_info_typeid.cpp
@@ -95,7 +95,7 @@ BOOST_SERIALIZATION_DECL void
 extended_type_info_typeid_0::type_unregister()
 {
     if(NULL != m_ti){
-        BOOST_ASSERT(! singleton<tkmap>::is_destroyed());
+        // Check that the singleton is still alive (might be unloaded already)
         if(! singleton<tkmap>::is_destroyed()){
             tkmap & x = singleton<tkmap>::get_mutable_instance();
 

--- a/src/void_cast.cpp
+++ b/src/void_cast.cpp
@@ -276,7 +276,6 @@ void_caster::recursive_register(bool includes_virtual_base) const {
 
 BOOST_SERIALIZATION_DECL void
 void_caster::recursive_unregister() const {
-    BOOST_ASSERT(! void_caster_registry::is_destroyed());
     if(void_caster_registry::is_destroyed())
         return;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -67,6 +67,13 @@ lib multi_shared_2
     :
         <link>shared
     ;
+lib test_singleton_lib
+    :
+        test_singleton_lib.cpp
+        ../build//boost_serialization
+    :
+        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
+    ;
 
 test-suite "serialization" :
      [ test-bsl-run_files test_array : A : :  [ requires cxx11_hdr_array ] ] # BOOST_NO_CXX11_HDR_ARRAY
@@ -145,7 +152,7 @@ if ! $(BOOST_ARCHIVE_LIST) {
     test-suite "serialization2" :
         [ test-bsl-run test_inclusion ]
         [ test-bsl-run test_inclusion2 ]
-        # boost build has the feature that the building if libraries vs dll is automatic
+        # boost build has the feature that the building of libraries vs dll is automatic
         # in that dependent libraries are built the same way - shared/static - that
         # the application is.  On some platforms (e.g windows) this is required to avoid
         # problems of linking incompatible versions of the runtime library.  So
@@ -153,6 +160,7 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_dll_exported : : polymorphic_derived2 : <link>static:<build>no ]
 
         # [ test-bsl-run test_dll_plugin : : polymorphic_derived2 : <link>static:<build>no <target-os>linux:<linkflags>-ldl ]
+        [ test-bsl-run test_singleton_shared : : test_singleton_lib ]
 
         # Tests using shared libraries which are linked against static boost. Hence ignore for shared boost build
         [ test-bsl-run test_multi_shared_lib : : multi_shared_1 multi_shared_2 : <link>shared:<build>no ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,8 +1,8 @@
 # Boost serialization Library test Jamfile
 
 #  (C) Copyright Robert Ramey 2002-2004.
-#  Use, modification, and distribution are subject to the 
-#  Boost Software License, Version 1.0. (See accompanying file 
+#  Use, modification, and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
@@ -28,28 +28,44 @@ import ../util/test :
 ;
 
 BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;
-    
+
 lib a
-    : 
+    :
         dll_a.cpp
         ../build//boost_serialization
-    : 
-        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 
+    :
+        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
     ;
 lib polymorphic_base
     :
-        polymorphic_base.cpp 
+        polymorphic_base.cpp
         ../build//boost_serialization
-    : 
-        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 
+    :
+        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
     ;
 
 lib polymorphic_derived2
     :
         polymorphic_derived2.cpp
         ../build//boost_serialization
-    : 
-        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 
+    :
+        <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
+    ;
+
+lib multi_shared_1
+    :
+        multi_shared1.cpp
+        ../build//boost_serialization/<link>static
+    :
+        <link>shared
+    ;
+
+lib multi_shared_2
+    :
+        multi_shared2.cpp
+        ../build//boost_serialization/<link>static
+    :
+        <link>shared
     ;
 
 test-suite "serialization" :
@@ -126,7 +142,7 @@ test-suite "serialization" :
     ;
 
 if ! $(BOOST_ARCHIVE_LIST) {
-    test-suite "serialization2" : 
+    test-suite "serialization2" :
         [ test-bsl-run test_inclusion ]
         [ test-bsl-run test_inclusion2 ]
         # boost build has the feature that the building if libraries vs dll is automatic
@@ -138,6 +154,8 @@ if ! $(BOOST_ARCHIVE_LIST) {
 
         # [ test-bsl-run test_dll_plugin : : polymorphic_derived2 : <link>static:<build>no <target-os>linux:<linkflags>-ldl ]
 
+        # Tests using shared libraries which are linked against static boost. Hence ignore for shared boost build
+        [ test-bsl-run test_multi_shared_lib : : multi_shared_1 multi_shared_2 : <link>shared:<build>no ]
         [ test-bsl-run test_dll_simple   : : a : ]
         [ test-bsl-run test_private_ctor ]
         [ test-bsl-run test_reset_object_address : A ]
@@ -172,7 +190,7 @@ if ! $(BOOST_ARCHIVE_LIST) {
         #[ compile test_const_save_warn1_nvp.cpp ]
         #[ compile test_const_save_warn2_nvp.cpp ]
         #[ compile test_const_save_warn3_nvp.cpp ]
-        
+
         # should compile
         [ compile test_traits_pass.cpp ]
         [ compile test_const_pass.cpp ]

--- a/test/multi_shared1.cpp
+++ b/test/multi_shared1.cpp
@@ -1,0 +1,16 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_multi_shared_lib.cpp: test that implementation of extented_type_info
+//		works when using multiple shared libraries
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/serialization/extended_type_info_typeid.hpp>
+
+BOOST_SYMBOL_EXPORT bool f(){
+  // Make sure to return true.
+  const char* impossible = "impossible";
+  return impossible != boost::serialization::extended_type_info_typeid<int>::get_const_instance().get_key();
+}

--- a/test/multi_shared2.cpp
+++ b/test/multi_shared2.cpp
@@ -1,0 +1,16 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// multi_shared2.cpp: library simply using extended_type_info_typeid
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/serialization/extended_type_info_typeid.hpp>
+
+BOOST_SYMBOL_EXPORT bool g(){
+  // Use a different(!) type than multi_shared1
+  // Make sure to return true.
+  const char* impossible = "impossible";
+  return impossible != boost::serialization::extended_type_info_typeid<float>::get_const_instance().get_key();
+}

--- a/test/test_multi_shared_lib.cpp
+++ b/test/test_multi_shared_lib.cpp
@@ -1,0 +1,30 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_multi_shared_lib.cpp: test that implementation of extented_type_info
+//		works when using multiple shared libraries
+//
+// This reproduces a crash that occurred when multiple shared libraries were
+// using Boost.Serialization built statically. That causes core singletons to be
+// instantiated in each shared library separately. Due to some destruction order
+// mixup in the context of shared libraries on linux it is possible, that
+// singletons accessed in destructors of other singletons are already destructed.
+// Accessing them will then lead to a crash or memory corruption.
+// For this we need 2 shared libraries, linked against static boost. They need to
+// instantiate extended_type_info_typeid with different types, either by serializing
+// 2 types (which will do that internally) or by accessing the singletons directly.
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/serialization/config.hpp>
+
+// Both shall instantiate different(!) singletons and return true
+BOOST_SYMBOL_IMPORT bool f();
+BOOST_SYMBOL_IMPORT bool g();
+
+int main(int argc, char**){
+  if(f() && g())
+  	return 0;
+  return 1;
+}

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -16,23 +16,20 @@
 #include "test_singleton.hpp"
 #include <boost/serialization/singleton.hpp>
 
-class x {
-};
-
+template<class T>
 void
-test1(const x & x1, const x & x2){
+test1(const T & x1, const T & x2){
     BOOST_CHECK(& x1 == & x2);
 }
 
 void test_same_instance(){
-    const x & x1 = boost::serialization::singleton<x>::get_const_instance();
-    const x & x2 = boost::serialization::singleton<x>::get_const_instance();
-
-    BOOST_CHECK(& x1 == & x2);
-
     test1(
-        boost::serialization::singleton<x>::get_const_instance(),
-        boost::serialization::singleton<x>::get_const_instance()
+        boost::serialization::singleton<plainSingleton>::get_const_instance(),
+        boost::serialization::singleton<plainSingleton>::get_const_instance()
+    );
+    test1(
+        inheritedSingleton::get_const_instance(),
+        inheritedSingleton::get_const_instance()
     );
 };
 

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -1,14 +1,29 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-// test_singleton.cpp: test implementation of run-time casting of void pointers
+// test_singleton.cpp: test implementation of the singleton template
+//
+// - get_[const_]_instance returns the same instance everytime it is called
+// - is_destroyed returns false when singleton is active or uninitialized
+// - is_destroyed returns true when singleton is destructed
+// - the singleton is eventually destructed (no memory leak)
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 // <gennadiy.rozental@tfn.com>
 
 #include "test_tools.hpp"
+#include <boost/array.hpp>
+#include <boost/preprocessor/stringize.hpp>
 #include <boost/serialization/singleton.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_CHECK because destructors are called after program exit
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
 
 class x {
 };
@@ -30,9 +45,73 @@ void test_same_instance(){
     );
 };
 
+
+struct plainSingleton;
+struct inheritedSingleton;
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    boost::array<ConstructionState, 2> states;
+private:
+    controller() {
+        states[0] = states[1] = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// Just to not duplicate the checks and sets
+template<size_t T_num>
+struct baseClass{
+    baseClass(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        BOOST_TEST(controller::getInstance().states[T_num] == CS_UNINIT);
+        controller::getInstance().states[T_num] = CS_INIT;
+    }
+    ~baseClass() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_INIT);
+        controller::getInstance().states[T_num] = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+struct plainSingleton: baseClass<0>
+{};
+
+struct inheritedSingleton: baseClass<1>, boost::serialization::singleton<inheritedSingleton>
+{};
+
+// Define after the classes:
+
+inline controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    for(size_t i=0; i<states.size(); i++)
+        THROW_ON_FALSE(states[i] == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<plainSingleton>::is_destroyed());
+    THROW_ON_FALSE(boost::serialization::singleton<inheritedSingleton>::is_destroyed());
+    THROW_ON_FALSE(inheritedSingleton::is_destroyed());
+}
+
 int
 test_main( int /* argc */, char* /* argv */[] )
 {
     test_same_instance();
+    // Check if the singletons are alive and use them
+    BOOST_CHECK(!boost::serialization::singleton<plainSingleton>::is_destroyed());
+    BOOST_CHECK(!inheritedSingleton::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<plainSingleton>::get_const_instance().i == 42);
+    BOOST_CHECK(inheritedSingleton::get_const_instance().i == 42);
     return EXIT_SUCCESS;
 }
+

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -1,74 +1,38 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-// test_singleton.cpp
+// test_singleton.cpp: test implementation of run-time casting of void pointers
 
-// (C) Copyright 2018 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-
-// should pass compilation and execution
-
-#include <iostream>
-#include <boost/serialization/singleton.hpp>
+// <gennadiy.rozental@tfn.com>
 
 #include "test_tools.hpp"
+#include <boost/serialization/singleton.hpp>
 
-static int i = 0;
-
-struct A {
-    int m_id;
-    A() : m_id(++i) {}
-    ~A(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
+class x {
 };
 
-struct B {
-    int m_id;
-    B() : m_id(++i) {}
-    ~B(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
-};
-
-struct C {
-    int m_id;
-    C() : m_id(++i) {}
-    ~C(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
-};
-
-struct D {
-    int m_id;
-    D(){
-        // verify that only one object is indeed created
-        const C & c = boost::serialization::singleton<C>::get_const_instance();
-        const C & c1 = boost::serialization::singleton<C>::get_const_instance();
-        BOOST_CHECK_EQUAL(&c, &c1);
-
-        // verify that objects are created in sequence of definition
-        BOOST_CHECK_EQUAL(c.m_id, 1);
-        const B & b = boost::serialization::singleton<B>::get_const_instance();
-        BOOST_CHECK_EQUAL(b.m_id, 2);
-        const A & a = boost::serialization::singleton<A>::get_const_instance();
-        BOOST_CHECK_EQUAL(a.m_id, 3);
-        std::cout << a.m_id << b.m_id << c.m_id << '\n';
-
-        m_id = ++i;
-    }
-    ~D(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
-};
-
-int test_main(int, char *[]){
-    return 0;
+void
+test1(const x & x1, const x & x2){
+    BOOST_CHECK(& x1 == & x2);
 }
 
-// note: not a singleton
-D d;
+void test_same_instance(){
+    const x & x1 = boost::serialization::singleton<x>::get_const_instance();
+    const x & x2 = boost::serialization::singleton<x>::get_const_instance();
+
+    BOOST_CHECK(& x1 == & x2);
+
+    test1(
+        boost::serialization::singleton<x>::get_const_instance(),
+        boost::serialization::singleton<x>::get_const_instance()
+    );
+};
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    test_same_instance();
+    return EXIT_SUCCESS;
+}

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -13,17 +13,8 @@
 // <gennadiy.rozental@tfn.com>
 
 #include "test_tools.hpp"
-#include <boost/array.hpp>
-#include <boost/preprocessor/stringize.hpp>
+#include "test_singleton.hpp"
 #include <boost/serialization/singleton.hpp>
-#include <stdexcept>
-
-// Can't use BOOST_CHECK because destructors are called after program exit
-// We halso have to disable the Wterminate warning as we call this from dtors
-// C++ will terminate the program in such cases which is OK here
-#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wterminate"
 
 class x {
 };
@@ -45,69 +36,14 @@ void test_same_instance(){
     );
 };
 
-
-struct plainSingleton;
-struct inheritedSingleton;
-
-// Enum to designate the state of the singletonized instances
-enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
-
-// We need another singleton to check for the destruction of the singletons at program exit
-// We don't need all the magic for shared library anti-optimization and can keep it very simple
-struct controller{
-    static controller& getInstance(){
-        static controller instance;
-        return instance;
-    }
-    boost::array<ConstructionState, 2> states;
-private:
-    controller() {
-        states[0] = states[1] = CS_UNINIT;
-    }
-    ~controller();
-};
-
-// Just to not duplicate the checks and sets
-template<size_t T_num>
-struct baseClass{
-    baseClass(): i(42) {
-        // access controller singleton. Therefore controller will be constructed before this
-        BOOST_TEST(controller::getInstance().states[T_num] == CS_UNINIT);
-        controller::getInstance().states[T_num] = CS_INIT;
-    }
-    ~baseClass() {
-        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
-        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_INIT);
-        controller::getInstance().states[T_num] = CS_DESTROYED;
-    }
-    // Volatile to prevent compiler optimization from removing this
-    volatile int i;
-};
-
-struct plainSingleton: baseClass<0>
-{};
-
-struct inheritedSingleton: baseClass<1>, boost::serialization::singleton<inheritedSingleton>
-{};
-
-// Define after the classes:
-
-inline controller::~controller() {
-    // If this fails, the singletons were not freed and memory is leaked
-    for(size_t i=0; i<states.size(); i++)
-        THROW_ON_FALSE(states[i] == CS_DESTROYED);
-    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
-    THROW_ON_FALSE(boost::serialization::singleton<plainSingleton>::is_destroyed());
-    THROW_ON_FALSE(boost::serialization::singleton<inheritedSingleton>::is_destroyed());
-    THROW_ON_FALSE(inheritedSingleton::is_destroyed());
-}
-
 int
 test_main( int /* argc */, char* /* argv */[] )
 {
     test_same_instance();
     // Check if the singletons are alive and use them
     BOOST_CHECK(!boost::serialization::singleton<plainSingleton>::is_destroyed());
+    // For inherited we can use both: singleton<foo>::bar and foo::bar
+    BOOST_CHECK(!boost::serialization::singleton<inheritedSingleton>::is_destroyed());
     BOOST_CHECK(!inheritedSingleton::is_destroyed());
 
     BOOST_CHECK(boost::serialization::singleton<plainSingleton>::get_const_instance().i == 42);

--- a/test/test_singleton.hpp
+++ b/test/test_singleton.hpp
@@ -1,0 +1,85 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton.hpp: Test that singletons are correctly destructed
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_SERIALIZATION_TEST_SINGLETON_HPP
+#define BOOST_SERIALIZATION_TEST_SINGLETON_HPP
+
+#include <boost/preprocessor/stringize.hpp>
+#include <boost/serialization/singleton.hpp>
+#include <boost/array.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_TEST because:
+// a) destructors are called after program exit
+// b) This is intended to be used by shared libraries too which would then need their own report_errors call
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+
+struct plainSingleton;
+struct inheritedSingleton;
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    boost::array<ConstructionState, 2> states;
+private:
+    controller() {
+        states[0] = states[1] = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// Just to not duplicate the checks and sets
+template<size_t T_num>
+struct baseClass{
+    baseClass(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_UNINIT);
+        controller::getInstance().states[T_num] = CS_INIT;
+    }
+    ~baseClass() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_INIT);
+        controller::getInstance().states[T_num] = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+struct plainSingleton: baseClass<0>
+{};
+
+struct inheritedSingleton: baseClass<1>, boost::serialization::singleton<inheritedSingleton>
+{};
+
+// Define after the classes:
+
+inline controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    for(size_t i=0; i<states.size(); i++)
+        THROW_ON_FALSE(states[i] == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<plainSingleton>::is_destroyed());
+    THROW_ON_FALSE(boost::serialization::singleton<inheritedSingleton>::is_destroyed());
+    THROW_ON_FALSE(inheritedSingleton::is_destroyed());
+}
+
+#pragma GCC diagnostic pop
+
+#endif // BOOST_SERIALIZATION_TEST_SINGLETON_HPP
+

--- a/test/test_singleton_lib.cpp
+++ b/test/test_singleton_lib.cpp
@@ -1,0 +1,19 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton_lib.cpp: simple library using singletons to test usage in shared libraries
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_SERIALIZATION_TEST_SOURCE
+
+#include "test_singleton_lib.hpp"
+#include "test_singleton.hpp"
+
+int singleton_lib_query(int result){
+    return boost::serialization::singleton<plainSingleton>::get_const_instance().i
+    	- inheritedSingleton::get_const_instance().i
+    	+ result;
+}
+

--- a/test/test_singleton_lib.hpp
+++ b/test/test_singleton_lib.hpp
@@ -1,0 +1,21 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_SERIALIZATION_TEST_SINGLETON_LIB_HPP
+#define BOOST_SERIALIZATION_TEST_SINGLETON_LIB_HPP
+
+#include <boost/config.hpp>
+
+#ifdef BOOST_SERIALIZATION_TEST_SOURCE
+#define BOOST_SERIALIZATION_TEST_DECL BOOST_SYMBOL_EXPORT
+#else
+#define BOOST_SERIALIZATION_TEST_DECL BOOST_SYMBOL_IMPORT
+#endif
+
+// Simple method that should return result
+BOOST_SERIALIZATION_TEST_DECL int singleton_lib_query(int result);
+
+#endif // BOOST_SERIALIZATION_TEST_SINGLETON_LIB_HPP

--- a/test/test_singleton_shared.cpp
+++ b/test/test_singleton_shared.cpp
@@ -1,0 +1,29 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton_shared.cpp: test implementation of the singleton template
+//                            with shared libraries
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_tools.hpp"
+#include "test_singleton.hpp"
+#include "test_singleton_lib.hpp"
+#include <boost/serialization/singleton.hpp>
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    // Check "our" singletons
+    BOOST_CHECK(!boost::serialization::singleton<plainSingleton>::is_destroyed());
+    BOOST_CHECK(!inheritedSingleton::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<plainSingleton>::get_const_instance().i == 42);
+    BOOST_CHECK(inheritedSingleton::get_const_instance().i == 42);
+
+    // Call into library to check the singletons there
+    BOOST_CHECK(singleton_lib_query(1337) == 1337);
+    return EXIT_SUCCESS;
+}
+

--- a/test/test_tools.hpp
+++ b/test/test_tools.hpp
@@ -193,7 +193,7 @@ int test_main(int argc, char * argv[]);
 
 int
 main(int argc, char * argv[]){
-    boost::serialization::get_singleton_module().lock();
+    boost::serialization::singleton_module::lock();
 
     int retval = 1;
     BOOST_TRY{
@@ -209,7 +209,7 @@ main(int argc, char * argv[]){
     }
     BOOST_CATCH_END
 
-    boost::serialization::get_singleton_module().unlock();
+    boost::serialization::singleton_module::unlock();
 
     int error_count = boost::report_errors();
     if(error_count > 0)


### PR DESCRIPTION
As described in #104 the singleton implementation was broken in https://github.com/boostorg/serialization/commit/b0a794da38b52c8ae0f8155cf3bb30321cf67f00 which led to crashes especially in the context of (multiple) shared libraries.

The "fix" allocating the instance on the heap basically just never freed the instances and hence leaked memory. This was due to not understanding the root cause of the problem.

To summarize:   
There are 2 use cases for the singleton: On where the type `T` is derived from `singleton<T>` and one where `singleton<T>` is used without deriving `T` from it. The above commit put the `is_destroyed` handling into the ctor/dtor of `singleton<T>`. However if `T` is not derived from it, then `singleton<T>` is never instantiated and hence `is_destroyed` is never set. See also some discussion in #104 and #79.

The crash/memory corruption now happens (or happened before the leaky implementation) if the `tkmap` used from `extended_type_info_typeid` is destroyed first. As it used from the ctor of `extended_type_info_typeid` this should normally not happen. However it does happen when used from multiple shared libraries under (at least) GCC 5.4 and 7.1. The reason is currently unknown (see https://stackoverflow.com/questions/50064617/order-of-destruction-for-static-function-members-in-shared-libraries) but we can just assume, the order of destruction is undefined. Hence the need for the `is_destroyed` flag.

On this PR:

- It is built on top of #94 to enable more testing
- It also tests in release mode to ensure that e.g. stripping of symbols by the linker does not cause problems
- Add a test case to ensure, that singletons are properly constructed, destroyed and the `is_destroyed` flag is correctly set
- Add a test case to test the same for shared libraries
- Add a test case based on https://gist.github.com/Flamefire/286e9e0e501731a04f10786450d3e711 to test the issue with multiple shared libraries. Before this PR this caused a double-free which is detected by the debug-glibc. It would be even better to run this in valgrind, but I'm not familiar enough with the Jam-Files and windows doesn't have it.
- Fix the failing testcases by partially reverting https://github.com/boostorg/serialization/commit/b0a794da38b52c8ae0f8155cf3bb30321cf67f00 :
- Reintroduce `detail:singleton_wrapper` with the correct `is_destroyed` setting in the dtor. It uses a method-local variable to enforce initialization on first use (preferred way to avoid static init disaster https://isocpp.org/wiki/faq/ctors#construct-on-first-use-v2) 
- Replace heap-allocated variable by static instance (see isocpp FAQ, avoids static init disaster and is thread safe)
- Assert `!is_destroyed` on enter of `get_instance`. Note that the comment was wrong. It did not refer to the instance and is even removed in non-debug builds
- Make the ctor of `singleton` protected and default to avoid accidental misuse (it might never be called if `T` is not derived from `singleton<T>`)
- Excessively comment everything to avoid breaking changes by misunderstandings

Other notes:

- The comment on the heap allocated variable was wrong: as `singleton_wrapper` is the most derived type of the instance it will always be destructed before `T` and `singleton<T>` (if `T` is derived from it) There is nothing one can do about it!
- Valgrind tests would be nice
- static instance is superior to static pointer (see isocpp FAQ), it is not about visibility, double-destruction or anything else. It simply makes sure that the instance is actually destructed at program exit
- Again: It is safe to assume the destruction order is undefined. Hence all asserts assuming otherwise have been removed (they had a runtime check afterwards anyway which is the correct way)
- Not deriving from `singleton<T>` but using it directly is potentially dangerous as you can have multiple `T` instances and you have only 1 `singleton<T>` where you might not expect it. Example: `extended_type_info` uses a `singleton<detail::tkmap>` to work around this issue because `extended_type_info_typeid` already uses a `singleton<tkmap>`. It might be wise to enforce deriving from `singleton<T>` and using `T::get_instance()` or at least do that in the library.

Finally: Please try to break this! I'm pretty sure I covered everything by using TDD but I might have missed something.