### PR TITLE
Fix tests

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -130,7 +130,6 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_dll_exported : : polymorphic_derived2 : <link>static:<build>no ]
 
         # [ test-bsl-run test_dll_plugin : : polymorphic_derived2 : <link>static:<build>no <target-os>linux:<linkflags>-ldl ]
-        [ test-bsl-run test_dll_plugin : : polymorphic_derived2 : <link>static:<build>no <target-os>linux:<linkflags>-ldl ]
 
         [ test-bsl-run test_dll_simple   : : a : ]
         [ test-bsl-run test_private_ctor ]

--- a/util/test.jam
+++ b/util/test.jam
@@ -156,18 +156,20 @@ rule test-bsl-run_archive ( test-name : archive-name : sources * : libs * : requ
     case "*_warchive" :
         tests +=  [
             run-winvoke $(test-name)_$(archive-name)
-            : 
+            : # sources
                 $(sources).cpp $(libs)
-            :
+            : # input files
+            : # requirements
                 <define>BOOST_ARCHIVE_TEST=$(archive-name).hpp
                 $(requirements)
         ] ;
     case "*" :
         tests +=  [
             run-invoke $(test-name)_$(archive-name)
-            : 
+            : # sources
                 $(sources).cpp $(libs)
-            : 
+            : # input files
+            : # requirements
                 <define>BOOST_ARCHIVE_TEST=$(archive-name).hpp
                 $(requirements)
         ] ;


### PR DESCRIPTION
8ca532a changed some bjam rule signatures in `util/test.jam`, but not all invocations of the changed rules were updated, systematically breaking test builds.

Also, the "test_dll_plugin" test was re-activated. However, as it is now it can't work - the `.so`/`.dll` name used doesn't match what's built.

Both of these issues are fixed by this PR.