### PR TITLE
Add singleton tests (Failure is expected)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,20 @@ matrix:
   include:
     - os: linux
       compiler: g++
-      env: TOOLSET=gcc
+      env: TOOLSET=gcc VARIANT=debug
 
     - os: linux
+      compiler: g++
+      env: TOOLSET=gcc VARIANT=release
+
+    - os: linux
+      compiler: g++
+      env: TOOLSET=gcc LINK=static VARIANT=debug,release
+
+    - &linux_gcc5
+      os: linux
       compiler: g++-5
-      env: TOOLSET=gcc-5
+      env: TOOLSET=gcc-5 VARIANT=debug
       addons:
         apt:
           packages:
@@ -39,9 +48,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - os: linux
+    - <<: *linux_gcc5
+      env: TOOLSET=gcc-5 VARIANT=release
+
+    - <<: *linux_gcc5
+      env: TOOLSET=gcc-5 LINK=static VARIANT=debug,release
+
+    - &linux_gcc6
+      os: linux
       compiler: g++-6
-      env: TOOLSET=gcc-6
+      env: TOOLSET=gcc-6 VARIANT=debug
       addons:
         apt:
           packages:
@@ -49,9 +65,16 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - os: linux
+    - <<: *linux_gcc6
+      env: TOOLSET=gcc-6 VARIANT=release
+
+    - <<: *linux_gcc6
+      env: TOOLSET=gcc-6 LINK=static VARIANT=debug,release
+
+    - &linux_gcc7
+      os: linux
       compiler: g++-7
-      env: TOOLSET=gcc-7
+      env: TOOLSET=gcc-7 VARIANT=debug
       addons:
         apt:
           packages:
@@ -59,31 +82,35 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    - os: linux
-      compiler: g++-7
-      env: TOOLSET=gcc-7 LINK=static
-      addons:
-        apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
+    - <<: *linux_gcc7
+      env: TOOLSET=gcc-7 VARIANT=release
+
+    - <<: *linux_gcc7
+      env: TOOLSET=gcc-7 LINK=static VARIANT=debug,release
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang
+      env: TOOLSET=clang VARIANT=debug
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang LINK=static
+      env: TOOLSET=clang VARIANT=release
+
+    - os: linux
+      compiler: clang++
+      env: TOOLSET=clang LINK=static VARIANT=debug,release
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang
+      env: TOOLSET=clang VARIANT=debug
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang LINK=static
+      env: TOOLSET=clang VARIANT=release
+
+    - os: osx
+      compiler: clang++
+      env: TOOLSET=clang LINK=static VARIANT=debug,release
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
@@ -99,7 +126,7 @@ install:
   - ./b2 headers
 
 script:
-  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared}
+  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared} variant=${VARIANT}
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ branches:
   only:
     - develop
 #    - master
+    - /feature\/.*/
 
 environment:
   matrix:
@@ -25,7 +26,9 @@ environment:
 
 install:
   - cd ..
-  - git clone -b %APPVEYOR_REPO_BRANCH%  https://github.com/boostorg/boost.git boost-root
+  - set BOOST_BRANCH=develop
+  - if "%APPVEYOR_REPO_BRANCH%"=="master" set BOOST_BRANCH=master
+  - git clone -b %BOOST_BRANCH%  https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule init libs/align
   - git submodule init libs/array

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cd ..
   - set BOOST_BRANCH=develop
   - if "%APPVEYOR_REPO_BRANCH%"=="master" set BOOST_BRANCH=master
-  - git clone -b %BOOST_BRANCH%  https://github.com/boostorg/boost.git boost-root
+  - git clone -b %BOOST_BRANCH% --depth=1 https://github.com/boostorg/boost.git boost-root
   - cd boost-root
   - git submodule init libs/align
   - git submodule init libs/array
@@ -80,4 +80,4 @@ build: off
 
 test_script:
   - cd libs/serialization/test
-  - b2 -j2 toolset=%BUILD_TOOLSET% link=%BUILD_LINK%
+  - b2 -j2 toolset=%BUILD_TOOLSET% link=%BUILD_LINK% variant=debug,release

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -16,23 +16,20 @@
 #include "test_singleton.hpp"
 #include <boost/serialization/singleton.hpp>
 
-class x {
-};
-
+template<class T>
 void
-test1(const x & x1, const x & x2){
+test1(const T & x1, const T & x2){
     BOOST_CHECK(& x1 == & x2);
 }
 
 void test_same_instance(){
-    const x & x1 = boost::serialization::singleton<x>::get_const_instance();
-    const x & x2 = boost::serialization::singleton<x>::get_const_instance();
-
-    BOOST_CHECK(& x1 == & x2);
-
     test1(
-        boost::serialization::singleton<x>::get_const_instance(),
-        boost::serialization::singleton<x>::get_const_instance()
+        boost::serialization::singleton<plainSingleton>::get_const_instance(),
+        boost::serialization::singleton<plainSingleton>::get_const_instance()
+    );
+    test1(
+        inheritedSingleton::get_const_instance(),
+        inheritedSingleton::get_const_instance()
     );
 };
 

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -1,14 +1,29 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-// test_singleton.cpp: test implementation of run-time casting of void pointers
+// test_singleton.cpp: test implementation of the singleton template
+//
+// - get_[const_]_instance returns the same instance everytime it is called
+// - is_destroyed returns false when singleton is active or uninitialized
+// - is_destroyed returns true when singleton is destructed
+// - the singleton is eventually destructed (no memory leak)
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 // <gennadiy.rozental@tfn.com>
 
 #include "test_tools.hpp"
+#include <boost/array.hpp>
+#include <boost/preprocessor/stringize.hpp>
 #include <boost/serialization/singleton.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_CHECK because destructors are called after program exit
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
 
 class x {
 };
@@ -30,9 +45,73 @@ void test_same_instance(){
     );
 };
 
+
+struct plainSingleton;
+struct inheritedSingleton;
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    boost::array<ConstructionState, 2> states;
+private:
+    controller() {
+        states[0] = states[1] = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// Just to not duplicate the checks and sets
+template<size_t T_num>
+struct baseClass{
+    baseClass(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        BOOST_TEST(controller::getInstance().states[T_num] == CS_UNINIT);
+        controller::getInstance().states[T_num] = CS_INIT;
+    }
+    ~baseClass() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_INIT);
+        controller::getInstance().states[T_num] = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+struct plainSingleton: baseClass<0>
+{};
+
+struct inheritedSingleton: baseClass<1>, boost::serialization::singleton<inheritedSingleton>
+{};
+
+// Define after the classes:
+
+inline controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    for(size_t i=0; i<states.size(); i++)
+        THROW_ON_FALSE(states[i] == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<plainSingleton>::is_destroyed());
+    THROW_ON_FALSE(boost::serialization::singleton<inheritedSingleton>::is_destroyed());
+    THROW_ON_FALSE(inheritedSingleton::is_destroyed());
+}
+
 int
 test_main( int /* argc */, char* /* argv */[] )
 {
     test_same_instance();
+    // Check if the singletons are alive and use them
+    BOOST_CHECK(!boost::serialization::singleton<plainSingleton>::is_destroyed());
+    BOOST_CHECK(!inheritedSingleton::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<plainSingleton>::get_const_instance().i == 42);
+    BOOST_CHECK(inheritedSingleton::get_const_instance().i == 42);
     return EXIT_SUCCESS;
 }
+

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -1,74 +1,38 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-// test_singleton.cpp
+// test_singleton.cpp: test implementation of run-time casting of void pointers
 
-// (C) Copyright 2018 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
-
-// should pass compilation and execution
-
-#include <iostream>
-#include <boost/serialization/singleton.hpp>
+// <gennadiy.rozental@tfn.com>
 
 #include "test_tools.hpp"
+#include <boost/serialization/singleton.hpp>
 
-static int i = 0;
-
-struct A {
-    int m_id;
-    A() : m_id(++i) {}
-    ~A(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
+class x {
 };
 
-struct B {
-    int m_id;
-    B() : m_id(++i) {}
-    ~B(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
-};
-
-struct C {
-    int m_id;
-    C() : m_id(++i) {}
-    ~C(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
-};
-
-struct D {
-    int m_id;
-    D(){
-        // verify that only one object is indeed created
-        const C & c = boost::serialization::singleton<C>::get_const_instance();
-        const C & c1 = boost::serialization::singleton<C>::get_const_instance();
-        BOOST_CHECK_EQUAL(&c, &c1);
-
-        // verify that objects are created in sequence of definition
-        BOOST_CHECK_EQUAL(c.m_id, 1);
-        const B & b = boost::serialization::singleton<B>::get_const_instance();
-        BOOST_CHECK_EQUAL(b.m_id, 2);
-        const A & a = boost::serialization::singleton<A>::get_const_instance();
-        BOOST_CHECK_EQUAL(a.m_id, 3);
-        std::cout << a.m_id << b.m_id << c.m_id << '\n';
-
-        m_id = ++i;
-    }
-    ~D(){
-        // verify that objects are destroyed in sequence reverse of construction
-        if(i-- != m_id) std::terminate();
-    }
-};
-
-int test_main(int, char *[]){
-    return 0;
+void
+test1(const x & x1, const x & x2){
+    BOOST_CHECK(& x1 == & x2);
 }
 
-// note: not a singleton
-D d;
+void test_same_instance(){
+    const x & x1 = boost::serialization::singleton<x>::get_const_instance();
+    const x & x2 = boost::serialization::singleton<x>::get_const_instance();
+
+    BOOST_CHECK(& x1 == & x2);
+
+    test1(
+        boost::serialization::singleton<x>::get_const_instance(),
+        boost::serialization::singleton<x>::get_const_instance()
+    );
+};
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    test_same_instance();
+    return EXIT_SUCCESS;
+}

--- a/test/test_singleton.cpp
+++ b/test/test_singleton.cpp
@@ -13,17 +13,8 @@
 // <gennadiy.rozental@tfn.com>
 
 #include "test_tools.hpp"
-#include <boost/array.hpp>
-#include <boost/preprocessor/stringize.hpp>
+#include "test_singleton.hpp"
 #include <boost/serialization/singleton.hpp>
-#include <stdexcept>
-
-// Can't use BOOST_CHECK because destructors are called after program exit
-// We halso have to disable the Wterminate warning as we call this from dtors
-// C++ will terminate the program in such cases which is OK here
-#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wterminate"
 
 class x {
 };
@@ -45,69 +36,14 @@ void test_same_instance(){
     );
 };
 
-
-struct plainSingleton;
-struct inheritedSingleton;
-
-// Enum to designate the state of the singletonized instances
-enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
-
-// We need another singleton to check for the destruction of the singletons at program exit
-// We don't need all the magic for shared library anti-optimization and can keep it very simple
-struct controller{
-    static controller& getInstance(){
-        static controller instance;
-        return instance;
-    }
-    boost::array<ConstructionState, 2> states;
-private:
-    controller() {
-        states[0] = states[1] = CS_UNINIT;
-    }
-    ~controller();
-};
-
-// Just to not duplicate the checks and sets
-template<size_t T_num>
-struct baseClass{
-    baseClass(): i(42) {
-        // access controller singleton. Therefore controller will be constructed before this
-        BOOST_TEST(controller::getInstance().states[T_num] == CS_UNINIT);
-        controller::getInstance().states[T_num] = CS_INIT;
-    }
-    ~baseClass() {
-        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
-        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_INIT);
-        controller::getInstance().states[T_num] = CS_DESTROYED;
-    }
-    // Volatile to prevent compiler optimization from removing this
-    volatile int i;
-};
-
-struct plainSingleton: baseClass<0>
-{};
-
-struct inheritedSingleton: baseClass<1>, boost::serialization::singleton<inheritedSingleton>
-{};
-
-// Define after the classes:
-
-inline controller::~controller() {
-    // If this fails, the singletons were not freed and memory is leaked
-    for(size_t i=0; i<states.size(); i++)
-        THROW_ON_FALSE(states[i] == CS_DESTROYED);
-    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
-    THROW_ON_FALSE(boost::serialization::singleton<plainSingleton>::is_destroyed());
-    THROW_ON_FALSE(boost::serialization::singleton<inheritedSingleton>::is_destroyed());
-    THROW_ON_FALSE(inheritedSingleton::is_destroyed());
-}
-
 int
 test_main( int /* argc */, char* /* argv */[] )
 {
     test_same_instance();
     // Check if the singletons are alive and use them
     BOOST_CHECK(!boost::serialization::singleton<plainSingleton>::is_destroyed());
+    // For inherited we can use both: singleton<foo>::bar and foo::bar
+    BOOST_CHECK(!boost::serialization::singleton<inheritedSingleton>::is_destroyed());
     BOOST_CHECK(!inheritedSingleton::is_destroyed());
 
     BOOST_CHECK(boost::serialization::singleton<plainSingleton>::get_const_instance().i == 42);

--- a/test/test_singleton.hpp
+++ b/test/test_singleton.hpp
@@ -1,0 +1,85 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton.hpp: Test that singletons are correctly destructed
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_SERIALIZATION_TEST_SINGLETON_HPP
+#define BOOST_SERIALIZATION_TEST_SINGLETON_HPP
+
+#include <boost/preprocessor/stringize.hpp>
+#include <boost/serialization/singleton.hpp>
+#include <boost/array.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_TEST because:
+// a) destructors are called after program exit
+// b) This is intended to be used by shared libraries too which would then need their own report_errors call
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+
+struct plainSingleton;
+struct inheritedSingleton;
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    boost::array<ConstructionState, 2> states;
+private:
+    controller() {
+        states[0] = states[1] = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// Just to not duplicate the checks and sets
+template<size_t T_num>
+struct baseClass{
+    baseClass(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_UNINIT);
+        controller::getInstance().states[T_num] = CS_INIT;
+    }
+    ~baseClass() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().states[T_num] == CS_INIT);
+        controller::getInstance().states[T_num] = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+struct plainSingleton: baseClass<0>
+{};
+
+struct inheritedSingleton: baseClass<1>, boost::serialization::singleton<inheritedSingleton>
+{};
+
+// Define after the classes:
+
+inline controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    for(size_t i=0; i<states.size(); i++)
+        THROW_ON_FALSE(states[i] == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<plainSingleton>::is_destroyed());
+    THROW_ON_FALSE(boost::serialization::singleton<inheritedSingleton>::is_destroyed());
+    THROW_ON_FALSE(inheritedSingleton::is_destroyed());
+}
+
+#pragma GCC diagnostic pop
+
+#endif // BOOST_SERIALIZATION_TEST_SINGLETON_HPP
+


### PR DESCRIPTION
Spinoff of #105 

This adds additional test variants and also builds tests of feature branches on appveyor.

The main contribution is the test of the `singleton::is_destroyed` behaviour:

- Checks that `is_destroyed` returns `true` if, and only if` the singleton is destroyed
- Checks that the singleton is actually destroyed (no memory leaks)

This should prevent regressions when changing the implementation details of `singleton`