### PR TITLE
Add missing template args to unordered_map<> serialization

### DIFF
--- a/include/boost/serialization/boost_unordered_map.hpp
+++ b/include/boost/serialization/boost_unordered_map.hpp
@@ -34,39 +34,41 @@ namespace serialization {
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void save(
     Archive & ar,
-    const boost::unordered_map<Key, HashFcn, EqualKey, Allocator> &t,
+    const boost::unordered_map<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
         Archive, 
-        boost::unordered_map<Key, HashFcn, EqualKey, Allocator>
+        boost::unordered_map<Key, T, HashFcn, EqualKey, Allocator>
     >(ar, t);
 }
 
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void load(
     Archive & ar,
-    boost::unordered_map<Key, HashFcn, EqualKey, Allocator> &t,
+    boost::unordered_map<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::load_unordered_collection<
         Archive,
-        boost::unordered_map<Key, HashFcn, EqualKey, Allocator>,
+        boost::unordered_map<Key, T, HashFcn, EqualKey, Allocator>,
         boost::serialization::stl::archive_input_unordered_map<
             Archive, 
-            boost::unordered_map<Key, HashFcn, EqualKey, Allocator>
+            boost::unordered_map<Key, T, HashFcn, EqualKey, Allocator>
         >
     >(ar, t);
 }
@@ -76,13 +78,14 @@ inline void load(
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void serialize(
     Archive & ar,
-    boost::unordered_map<Key, HashFcn, EqualKey, Allocator> &t,
+    boost::unordered_map<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int file_version
 ){
     boost::serialization::split_free(ar, t, file_version);
@@ -92,24 +95,26 @@ inline void serialize(
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void save(
     Archive & ar,
-    const boost::unordered_multimap<Key, HashFcn, EqualKey, Allocator> &t,
+    const boost::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
         Archive, 
-        boost::unordered_multimap<Key, HashFcn, EqualKey, Allocator>
+        boost::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator>
     >(ar, t);
 }
 
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
@@ -117,16 +122,16 @@ template<
 inline void load(
     Archive & ar,
     boost::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, T, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::load_unordered_collection<
         Archive,
-        boost::unordered_multimap<Key, HashFcn, EqualKey, Allocator>,
+        boost::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator>,
         boost::serialization::stl::archive_input_unordered_multimap<
             Archive, 
-            boost::unordered_multimap<Key, HashFcn, EqualKey, Allocator>
+            boost::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator>
         >
     >(ar, t);
 }
@@ -136,13 +141,14 @@ inline void load(
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void serialize(
     Archive & ar,
-    boost::unordered_multimap<Key, HashFcn, EqualKey, Allocator> &t,
+    boost::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int file_version
 ){
     boost::serialization::split_free(ar, t, file_version);

--- a/include/boost/serialization/unordered_map.hpp
+++ b/include/boost/serialization/unordered_map.hpp
@@ -33,40 +33,42 @@ namespace serialization {
 
 template<
     class Archive, 
-    class Key, 
+    class Key,
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void save(
     Archive & ar,
-    const std::unordered_map<Key, HashFcn, EqualKey, Allocator> &t,
+    const std::unordered_map<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
         Archive, 
-        std::unordered_map<Key, HashFcn, EqualKey, Allocator>
+        std::unordered_map<Key, T, HashFcn, EqualKey, Allocator>
     >(ar, t);
 }
 
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void load(
     Archive & ar,
-    std::unordered_map<Key, HashFcn, EqualKey, Allocator> &t,
+    std::unordered_map<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::load_unordered_collection<
         Archive,
-        std::unordered_map<Key, HashFcn, EqualKey, Allocator>,
+        std::unordered_map<Key, T, HashFcn, EqualKey, Allocator>,
         boost::serialization::stl::archive_input_unordered_map<
             Archive, 
-            std::unordered_map<Key, HashFcn, EqualKey, Allocator>
+            std::unordered_map<Key, T, HashFcn, EqualKey, Allocator>
         >
     >(ar, t);
 }
@@ -76,13 +78,14 @@ inline void load(
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
 >
 inline void serialize(
     Archive & ar,
-    std::unordered_map<Key, HashFcn, EqualKey, Allocator> &t,
+    std::unordered_map<Key, T, HashFcn, EqualKey, Allocator> &t,
     const unsigned int file_version
 ){
     boost::serialization::split_free(ar, t, file_version);
@@ -92,6 +95,7 @@ inline void serialize(
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
@@ -99,19 +103,20 @@ template<
 inline void save(
     Archive & ar,
     const std::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, T, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::save_unordered_collection<
         Archive, 
-        std::unordered_multimap<Key, HashFcn, EqualKey, Allocator>
+        std::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator>
     >(ar, t);
 }
 
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
@@ -119,18 +124,18 @@ template<
 inline void load(
     Archive & ar,
     std::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, T, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int /*file_version*/
 ){
     boost::serialization::stl::load_unordered_collection<
         Archive,
         std::unordered_multimap<
-            Key, HashFcn, EqualKey, Allocator
+            Key, T, HashFcn, EqualKey, Allocator
         >,
         boost::serialization::stl::archive_input_unordered_multimap<
             Archive, 
-            std::unordered_multimap<Key, HashFcn, EqualKey, Allocator>
+            std::unordered_multimap<Key, T, HashFcn, EqualKey, Allocator>
         >
     >(ar, t);
 }
@@ -140,6 +145,7 @@ inline void load(
 template<
     class Archive, 
     class Key, 
+    class T,
     class HashFcn, 
     class EqualKey,
     class Allocator
@@ -147,7 +153,7 @@ template<
 inline void serialize(
     Archive & ar,
     std::unordered_multimap<
-        Key, HashFcn, EqualKey, Allocator
+        Key, T, HashFcn, EqualKey, Allocator
     > &t,
     const unsigned int file_version
 ){


### PR DESCRIPTION
Both `std::unordered_map<>` and `boost::unordered_map<>` miss the template argument for the value.
Probably went unnoticed as this would only surface with a non-standard allocator.