### PR TITLE
Fixed catch by value warnings in tests

### DIFF
--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -58,7 +58,7 @@ int test_std_array(){
             BOOST_TRY {
                 ia >> boost::serialization::make_nvp("a_array", a_array1);
             }
-            BOOST_CATCH (boost::archive::archive_exception ae){
+            BOOST_CATCH (boost::archive::archive_exception const& ae){
                 BOOST_CHECK(
                     boost::archive::archive_exception::array_size_too_short
                     == ae.code

--- a/test/test_boost_array.cpp
+++ b/test/test_boost_array.cpp
@@ -59,7 +59,7 @@ int test_boost_array(){
             BOOST_TRY {
                 ia >> boost::serialization::make_nvp("a_array", a_array1);
             }
-            BOOST_CATCH (boost::archive::archive_exception ae){
+            BOOST_CATCH (boost::archive::archive_exception const& ae){
                 BOOST_CHECK(
                     boost::archive::archive_exception::array_size_too_short
                     == ae.code

--- a/test/test_cyclic_ptrs.cpp
+++ b/test/test_cyclic_ptrs.cpp
@@ -163,7 +163,7 @@ int test3(){
         BOOST_TRY {
             oa << BOOST_SERIALIZATION_NVP(k);
         }
-        BOOST_CATCH (boost::archive::archive_exception ae){
+        BOOST_CATCH (boost::archive::archive_exception const& ae){
             exception = ae;
         }
         BOOST_CATCH_END
@@ -182,7 +182,7 @@ int test3(){
         BOOST_TRY {
             ia >> BOOST_SERIALIZATION_NVP(k);
         }
-        BOOST_CATCH (boost::archive::archive_exception ae){
+        BOOST_CATCH (boost::archive::archive_exception const& ae){
             exception = ae;
         }
         BOOST_CATCH_END

--- a/test/test_interrupts.cpp
+++ b/test/test_interrupts.cpp
@@ -56,7 +56,7 @@ int test_out(){
                 BOOST_TRY {
                     oa << BOOST_SERIALIZATION_NVP(t);
                 }
-                BOOST_CATCH (boost::archive::archive_exception ae){
+                BOOST_CATCH (boost::archive::archive_exception const& ae){
                     BOOST_CHECK(
                         boost::archive::archive_exception::other_exception
                         == ae.code
@@ -66,7 +66,7 @@ int test_out(){
                 BOOST_CATCH_END
                 BOOST_CHECK(exception_invoked);
             }
-            BOOST_CATCH (boost::archive::archive_exception ae){}
+            BOOST_CATCH (boost::archive::archive_exception const& ae){}
             BOOST_CATCH_END
         }
         os.close();
@@ -113,7 +113,7 @@ int test_in(){
                 BOOST_TRY {
                     ia >> BOOST_SERIALIZATION_NVP(t1);
                 }
-                BOOST_CATCH (boost::archive::archive_exception ae){
+                BOOST_CATCH (boost::archive::archive_exception const& ae){
                     BOOST_CHECK(
                         boost::archive::archive_exception::other_exception
                         == ae.code
@@ -123,7 +123,7 @@ int test_in(){
                 BOOST_CATCH_END
                 BOOST_CHECK(exception_invoked);
             }
-            BOOST_CATCH (boost::archive::archive_exception ae){}
+            BOOST_CATCH (boost::archive::archive_exception const& ae){}
             BOOST_CATCH_END
         }
         is.close();

--- a/test/test_native_array.cpp
+++ b/test/test_native_array.cpp
@@ -69,7 +69,7 @@ int test_native_array(){
                 ia >> boost::serialization::make_nvp("a_array", a_array1);
                 ia >> boost::serialization::make_nvp("b_array", b_array1);
             }
-            BOOST_CATCH (boost::archive::archive_exception ae){
+            BOOST_CATCH (boost::archive::archive_exception const& ae){
                 BOOST_CHECK(
                     boost::archive::archive_exception::array_size_too_short
                     == ae.code

--- a/test/test_unregistered.cpp
+++ b/test/test_unregistered.cpp
@@ -85,7 +85,7 @@ void save_unregistered1(const char *testfile)
     BOOST_TRY {
         oa << BOOST_SERIALIZATION_NVP(rb1);
     }
-    BOOST_CATCH(boost::archive::archive_exception aex){
+    BOOST_CATCH(boost::archive::archive_exception const& aex){
         except = true;
     }
     BOOST_CATCH_END
@@ -112,7 +112,7 @@ void load_unregistered1(const char *testfile)
     BOOST_TRY {
         ia >> BOOST_SERIALIZATION_NVP(rb1);
     }
-    BOOST_CATCH(boost::archive::archive_exception aex){
+    BOOST_CATCH(boost::archive::archive_exception const& aex){
         except = true;
         BOOST_CHECK_MESSAGE(
             NULL == rb1,
@@ -140,7 +140,7 @@ void save_unregistered2(const char *testfile)
     BOOST_TRY {
         oa << BOOST_SERIALIZATION_NVP(rd1);
     }
-    BOOST_CATCH(boost::archive::archive_exception aex){
+    BOOST_CATCH(boost::archive::archive_exception const& aex){
         except = true;
     }
     BOOST_CATCH_END
@@ -166,7 +166,7 @@ void load_unregistered2(const char *testfile)
     BOOST_TRY {
         ia >> BOOST_SERIALIZATION_NVP(rd1);
     }
-    BOOST_CATCH(boost::archive::archive_exception aex){
+    BOOST_CATCH(boost::archive::archive_exception const& aex){
         except = true;
         BOOST_CHECK_MESSAGE(
             NULL == rd1, 
@@ -279,7 +279,7 @@ void load_unregistered_pointer(const char *testfile)
     BOOST_TRY {
         ia & BOOST_SERIALIZATION_NVP(instance1) & BOOST_SERIALIZATION_NVP(pointer2);
     }
-    BOOST_CATCH(boost::archive::archive_exception aex){
+    BOOST_CATCH(boost::archive::archive_exception const& aex){
         except = true;
         BOOST_CHECK_MESSAGE(
             std::strcmp(aex.what(), "unregistered class") == 0,

--- a/test/test_variant.cpp
+++ b/test/test_variant.cpp
@@ -135,7 +135,7 @@ void do_bad_read()
             bool exception_invoked = false;
             BOOST_TRY {
                 ia >> BOOST_SERIALIZATION_NVP(little_variant);
-            } BOOST_CATCH (boost::archive::archive_exception e) {
+            } BOOST_CATCH (boost::archive::archive_exception const& e) {
                 BOOST_CHECK(boost::archive::archive_exception::unsupported_version == e.code);
                 exception_invoked = true;
             }


### PR DESCRIPTION
warning: catching polymorphic type 'class boost::archive::archive_exception' by value [-Wcatch-value=]