### PR TITLE
Use endian macros from Predef

### DIFF
--- a/example/portable_binary_archive.hpp
+++ b/example/portable_binary_archive.hpp
@@ -21,7 +21,7 @@
 #endif
 
 #include <boost/archive/basic_archive.hpp>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 
 enum portable_binary_archive_flags {
     endian_big        = 0x4000,

--- a/example/portable_binary_iarchive.cpp
+++ b/example/portable_binary_iarchive.cpp
@@ -11,7 +11,7 @@
 #include <istream>
 #include <string>
 
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #include <boost/serialization/throw_exception.hpp>
 #include <boost/archive/archive_exception.hpp>
 
@@ -37,12 +37,12 @@ portable_binary_iarchive::load_impl(boost::intmax_t & l, char maxsize){
         );
 
     char * cptr = reinterpret_cast<char *>(& l);
-    #ifdef BOOST_BIG_ENDIAN
+    #if BOOST_ENDIAN_BIG_BYTE
         cptr += (sizeof(boost::intmax_t) - size);
     #endif
     this->primitive_base_t::load_binary(cptr, size);
 
-    #ifdef BOOST_BIG_ENDIAN
+    #if BOOST_ENDIAN_BIG_BYTE
         if(m_flags & endian_little)
     #else
         if(m_flags & endian_big)

--- a/example/portable_binary_oarchive.cpp
+++ b/example/portable_binary_oarchive.cpp
@@ -9,7 +9,7 @@
 //  See http://www.boost.org for updates, documentation, and revision history.
 
 #include <ostream>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 #include "portable_binary_oarchive.hpp"
 
 void 
@@ -45,7 +45,7 @@ portable_binary_oarchive::save_impl(
     else
         ll = l;
     char * cptr = reinterpret_cast<char *>(& ll);
-    #ifdef BOOST_BIG_ENDIAN
+    #if BOOST_ENDIAN_BIG_BYTE
         cptr += (sizeof(boost::intmax_t) - size);
         if(m_flags & endian_little)
             reverse_bytes(size, cptr);

--- a/include/boost/archive/impl/basic_binary_iarchive.ipp
+++ b/include/boost/archive/impl/basic_binary_iarchive.ipp
@@ -22,7 +22,7 @@ namespace std{
 #endif
 
 #include <boost/detail/workaround.hpp>
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 
 #include <boost/archive/basic_binary_iarchive.hpp>
 
@@ -89,7 +89,7 @@ basic_binary_iarchive<Archive>::init(void){
     {
         int v = 0;
         v = this->This()->m_sb.sbumpc();
-        #if defined(BOOST_LITTLE_ENDIAN)
+        #if BOOST_ENDIAN_LITTLE_BYTE
         if(v < 6){
             ;
         }
@@ -111,7 +111,7 @@ basic_binary_iarchive<Archive>::init(void){
             // version 8+ followed by a zero
             this->This()->m_sb.sbumpc();
         }
-        #elif defined(BOOST_BIG_ENDIAN)
+        #elif BOOST_ENDIAN_BIG_BYTE
         if(v == 0)
             v = this->This()->m_sb.sbumpc();
         #endif


### PR DESCRIPTION
The `boost/detail/endian.hpp` header is deprecated.

Fixes #134.