### PR TITLE
Show crash of #111 in a different way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 script:
   - |-
     echo "using $TOOLSET : : $TRAVIS_COMPILER ;" > ~/user-config.jam
-  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared}
+  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared} cxxflags=-fPIC cflags=-fPIC
 
 notifications:
   email:

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -52,6 +52,22 @@ lib dll_polymorphic_derived2
         <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 
     ;
 
+lib multi_shared_1
+    :
+        multi_shared1.cpp
+        ../build//boost_serialization/<link>static
+    :
+        <link>shared
+    ;
+
+lib multi_shared_2
+    :
+        multi_shared2.cpp
+        ../build//boost_serialization/<link>static
+    :
+        <link>shared
+    ;
+
 test-suite "serialization" :
      [ test-bsl-run_files test_array : A : :  [ requires cxx11_hdr_array ] ] # BOOST_NO_CXX11_HDR_ARRAY
      [ test-bsl-run_files test_boost_array : A ]
@@ -140,6 +156,8 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_dll_simple   : : dll_a : ]
         # [ test-bsl-run test_dll_plugin : : polymorphic_derived2 : <link>static:<build>no <target-os>linux:<linkflags>-ldl ]
 
+        # Tests using shared libraries which are linked against static boost. Hence ignore for shared boost build
+        [ test-bsl-run test_multi_shared_lib : : multi_shared_1 multi_shared_2 : <link>shared:<build>no ]
         [ test-bsl-run test_private_ctor ]
         [ test-bsl-run test_reset_object_address : A ]
         [ test-bsl-run test_void_cast ]


### PR DESCRIPTION
As @robertramey mentioned that the use of `extended_type_info` in #111 is invalid (can I have the related documentation for this?) I changed the example to be based on the official docu.

Base is the basic serialization in the tutorial: https://www.boost.org/doc/libs/1_67_0/libs/serialization/doc/tutorial.html
Additionally I want a specific level as described here: https://www.boost.org/doc/libs/1_67_0/libs/serialization/doc/traits.html#level

Hence this code should now show the valid use of 2 shared libraries (possibly from different vendors and completely unrelated) each using static Boost.Serialization in a straight forward way.

But it will show the exact same crash as in #111 due to the destruction order mixup with shared libraries on linux.