### PR TITLE
Add tests for singleton::is_destroyed

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -149,6 +149,8 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_smart_cast ]
         [ test-bsl-run test_codecvt_null ]
         [ test-bsl-run test_singleton ]
+        [ test-bsl-run test_singleton_plain ]
+        [ test-bsl-run test_singleton_inherited ]
 
         # [ test-bsl-run test_z ]
 

--- a/test/test_singleton_inherited.cpp
+++ b/test/test_singleton_inherited.cpp
@@ -1,0 +1,82 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton_inherited.cpp:
+// Test the singleton class for a "inherited" singleton (used as Foo:public singleton<Foo>)
+// This can be uses as singleton<Foo>::get_const_instance() OR Foo::get_const_instance()
+//
+// - is_destroyed returns false when singleton is active or uninitialized
+// - is_destroyed returns true when singleton is destructed
+// - the singleton is eventually destructed (no memory leak)
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_tools.hpp"
+#include <boost/serialization/singleton.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_TEST because:
+// a) destructors are called after program exit
+// b) This is intended to be used by shared libraries too which would then need their own report_errors call
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    ConstructionState state;
+private:
+    controller() {
+        state = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// A simple class that sets its construction state in the controller singleton
+struct Foo: boost::serialization::singleton<Foo>{
+    Foo(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        THROW_ON_FALSE(controller::getInstance().state == CS_UNINIT);
+        controller::getInstance().state = CS_INIT;
+    }
+    ~Foo() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().state == CS_INIT);
+        controller::getInstance().state = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    THROW_ON_FALSE(state == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<Foo>::is_destroyed());
+    THROW_ON_FALSE(Foo::is_destroyed());
+}
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    // Check if the singleton is alive and use it
+    BOOST_CHECK(!boost::serialization::singleton<Foo>::is_destroyed());
+    BOOST_CHECK(!Foo::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<Foo>::get_const_instance().i == 42);
+    BOOST_CHECK(Foo::get_const_instance().i == 42);
+    return EXIT_SUCCESS;
+}
+

--- a/test/test_singleton_plain.cpp
+++ b/test/test_singleton_plain.cpp
@@ -1,0 +1,78 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton_plain.cpp:
+// Test the singleton class for a "plain" singleton (used as singleton<Foo>)
+//
+// - is_destroyed returns false when singleton is active or uninitialized
+// - is_destroyed returns true when singleton is destructed
+// - the singleton is eventually destructed (no memory leak)
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_tools.hpp"
+#include <boost/serialization/singleton.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_TEST because:
+// a) destructors are called after program exit
+// b) This is intended to be used by shared libraries too which would then need their own report_errors call
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    ConstructionState state;
+private:
+    controller() {
+        state = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// A simple class that sets its construction state in the controller singleton
+struct Foo{
+    Foo(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        THROW_ON_FALSE(controller::getInstance().state == CS_UNINIT);
+        controller::getInstance().state = CS_INIT;
+    }
+    ~Foo() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().state == CS_INIT);
+        controller::getInstance().state = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    THROW_ON_FALSE(state == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<Foo>::is_destroyed());
+}
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    // Check if the singleton is alive and use it
+    BOOST_CHECK(!boost::serialization::singleton<Foo>::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<Foo>::get_const_instance().i == 42);
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
This is basically the same test as in #110.

However in #105 @pdimov noted, that it might be easier, to duplicate some test code and split it into 2 separate test cases (https://github.com/boostorg/serialization/pull/105#discussion_r225581561), so this is done here.

As mentioned in the [docu](https://www.boost.org/doc/libs/1_67_0/libs/serialization/doc/singleton.html) the singleton may be used in 2 cases and "Both are used in the serialization library. ":

- plain: simple class used as singleton<Foo>
- inherited: Foo inherits from singleton<Foo> and can be used directly

Furthermore there is `is_destroyed` which shall "Return true if the destructor on this singleton has been called. Otherwise, return false."

This behaviour is never tested which is the reason for this PR.

Assumption: Classes are destructed in the reverse order of the return from their constructor (see C++ standard) and static function objects are destructed at program termination. This is the base for the `controller` class:

- Accessed from the singleton under test `Foo` in its constructor -> `controller` is destructed after `Foo`
- `Foo`s ctor AND dtor will set a variable in the `controller` to the current state
- This state can be used in the dtor of `controller` to check that the singleton was destroyed (if it wasn't there would be a memory leak)
- The controller can also check `is_destroyed` of the singleton which must be `true` due to the former
- The main function checks the `is_destroyed` returns `false` and accesses any member of `Foo` to avoid its construction being eliminated.

As explained multiple times `is_destroyed` does not return `true` as it should for the plain singleton. #105 contains the fix for this (will rebase #105 when this is merged)