### PR TITLE
Fix singleton::is_destroyed and crash when using shared libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 script:
   - |-
     echo "using $TOOLSET : : $TRAVIS_COMPILER ;" > ~/user-config.jam
-  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared}
+  - ./b2 -j 3 libs/serialization/test toolset=$TOOLSET link=${LINK:-shared} cxxflags=-fPIC cflags=-fPIC
 
 notifications:
   email:

--- a/include/boost/archive/impl/archive_serializer_map.ipp
+++ b/include/boost/archive/impl/archive_serializer_map.ipp
@@ -47,10 +47,6 @@ archive_serializer_map<Archive>::insert(const basic_serializer * bs){
 template<class Archive>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL void
 archive_serializer_map<Archive>::erase(const basic_serializer * bs){
-    BOOST_ASSERT(! boost::serialization::singleton<
-            extra_detail::map<Archive>
-        >::is_destroyed()
-    );
     if(boost::serialization::singleton<
         extra_detail::map<Archive>
     >::is_destroyed())

--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -58,7 +58,7 @@ namespace serialization {
 // details.
 //
 
-// singletons created by this code are guarenteed to be unique
+// Singletons created by this code are guaranteed to be unique
 // within the executable or shared library which creates them.
 // This is sufficient and in fact ideal for the serialization library.
 // The singleton is created when the module is loaded and destroyed
@@ -74,14 +74,21 @@ namespace serialization {
 // Second, it provides a mechanism to detect when a non-const function
 // is called after initialization.
 
-// make a singleton to lock/unlock all singletons for alteration.
+// Make a singleton to lock/unlock all singletons for alteration.
 // The intent is that all singletons created/used by this code
 // are to be initialized before main is called. A test program
-// can lock all the singletons when main is entereed.  This any
-// attempt to retieve a mutable instances while locked will
-// generate a assertion if compiled for debug.
+// can lock all the singletons when main is entered.  Thus any
+// attempt to retrieve a mutable instance while locked will
+// generate an assertion if compiled for debug.
 
-// note usage of BOOST_DLLEXPORT.  These functions are in danger of
+// The singleton template can be used in 2 ways:
+// 1 (Recommended): Publicly inherit your type T from singleton<T>,
+// make its ctor protected and access it via T::get_const_instance()
+// 2: Simply access singleton<T> without changing T. Note that this only
+// provides a global instance accesible by singleton<T>::get_const_instance()
+// To prevent using multiple instances of T make its ctor protected
+
+// Note on usage of BOOST_DLLEXPORT: These functions are in danger of
 // being eliminated by the optimizer when building an application in
 // release mode. Usage of the macro is meant to signal the compiler/linker
 // to avoid dropping these functions which seem to be unreferenced.
@@ -113,34 +120,69 @@ static inline singleton_module & get_singleton_module(){
     return m;
 }
 
+namespace detail {
+
+// This is the class actually instantiated and hence the real singleton.
+// So there will only be one instance of this class. This does not hold
+// for singleton<T> as a class derived from singleton<T> could be
+// instantiated multiple times.
+// It also provides a flag `is_destroyed` which returns true, when the
+// class was destructed. It is static and hence accesible even after
+// destruction. This can be used to check, if the singleton is still
+// accesible e.g. in destructors of other singletons.
+template<class T>
+class singleton_wrapper : public T
+{
+    static bool & get_is_destroyed(){
+        // Prefer a static function member to avoid LNK1179.
+        // Note: As this is for a singleton (1 instance only) it must be set
+        // never be reset (to false)!
+        static bool is_destroyed_flag = false;
+        return is_destroyed_flag;
+    }
+public:
+    singleton_wrapper(){
+        BOOST_ASSERT(! is_destroyed());
+    }
+    ~singleton_wrapper(){
+        get_is_destroyed() = true;
+    }
+    static bool is_destroyed(){
+        return get_is_destroyed();
+    }
+};
+
+} // detail
+
 template <class T>
 class singleton {
 private:
-    // note presumption that T has a default constructor
     static T & m_instance;
     // include this to provoke instantiation at pre-execution time
     static void use(T const &) {}
     static T & get_instance() {
-        static T t;
-
-        // refer to instance, causing it to be instantiated (and
-        // initialized at startup on working compilers)
         BOOST_ASSERT(! is_destroyed());
+
+        // use a wrapper so that types T with protected constructors can be used
+        // Using a static function member avoids LNK1179
+        static detail::singleton_wrapper< T > t;
 
         // note that the following is absolutely essential.
         // commenting out this statement will cause compilers to fail to
         // construct the instance at pre-execution time.  This would prevent
         // our usage/implementation of "locking" and introduce uncertainty into
-        // the sequence of object initializaition.
+        // the sequence of object initialization.
         use(m_instance);
 
         return static_cast<T &>(t);
     }
 
-    static bool & get_is_destroyed(){
-        static bool is_destroyed;
-        return is_destroyed;
-    }
+
+protected:
+    // Do not allow instantiation of a singleton<T>. But we want to allow
+    // `class T: public singleton<T>` so we can't delete this ctor
+    BOOST_DLLEXPORT singleton(){}
+
 public:
     BOOST_DLLEXPORT static T & get_mutable_instance(){
         BOOST_ASSERT(! get_singleton_module().is_locked());
@@ -150,16 +192,12 @@ public:
         return get_instance();
     }
     BOOST_DLLEXPORT static bool is_destroyed(){
-        return get_is_destroyed();
-    }
-    BOOST_DLLEXPORT singleton(){
-        get_is_destroyed() = false;
-    }
-    BOOST_DLLEXPORT ~singleton() {
-        get_is_destroyed() = true;
+        return detail::singleton_wrapper< T >::is_destroyed();
     }
 };
 
+// Assigning the instance reference to a static member forces initialization
+// at startup time as described in http://tinyurl.com/ljdp8
 template<class T>
 T & singleton< T >::m_instance = singleton< T >::get_instance();
 

--- a/src/extended_type_info.cpp
+++ b/src/extended_type_info.cpp
@@ -125,7 +125,6 @@ BOOST_SERIALIZATION_DECL void
 extended_type_info::key_unregister() const{
     if(NULL == get_key())
         return;
-    BOOST_ASSERT(! singleton<detail::ktmap>::is_destroyed());
     if(! singleton<detail::ktmap>::is_destroyed()){
         detail::ktmap & x = singleton<detail::ktmap>::get_mutable_instance();
         detail::ktmap::iterator start = x.lower_bound(this);

--- a/src/extended_type_info_typeid.cpp
+++ b/src/extended_type_info_typeid.cpp
@@ -95,7 +95,7 @@ BOOST_SERIALIZATION_DECL void
 extended_type_info_typeid_0::type_unregister()
 {
     if(NULL != m_ti){
-        BOOST_ASSERT(! singleton<tkmap>::is_destroyed());
+        // Check that the singleton is still alive (might be unloaded already)
         if(! singleton<tkmap>::is_destroyed()){
             tkmap & x = singleton<tkmap>::get_mutable_instance();
 

--- a/src/void_cast.cpp
+++ b/src/void_cast.cpp
@@ -276,7 +276,6 @@ void_caster::recursive_register(bool includes_virtual_base) const {
 
 BOOST_SERIALIZATION_DECL void
 void_caster::recursive_unregister() const {
-    BOOST_ASSERT(! void_caster_registry::is_destroyed());
     if(void_caster_registry::is_destroyed())
         return;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -167,6 +167,8 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_smart_cast ]
         [ test-bsl-run test_codecvt_null ]
         [ test-bsl-run test_singleton ]
+        [ test-bsl-run test_singleton_plain ]
+        [ test-bsl-run test_singleton_inherited ]
 
         # [ test-bsl-run test_z ]
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -52,6 +52,22 @@ lib dll_polymorphic_derived2
         <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 
     ;
 
+lib multi_shared_1
+    :
+        multi_shared1.cpp
+        ../build//boost_serialization/<link>static
+    :
+        <link>shared
+    ;
+
+lib multi_shared_2
+    :
+        multi_shared2.cpp
+        ../build//boost_serialization/<link>static
+    :
+        <link>shared
+    ;
+
 test-suite "serialization" :
      [ test-bsl-run_files test_array : A : :  [ requires cxx11_hdr_array ] ] # BOOST_NO_CXX11_HDR_ARRAY
      [ test-bsl-run_files test_boost_array : A ]
@@ -140,6 +156,8 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_dll_simple   : : dll_a : ]
         # [ test-bsl-run test_dll_plugin : : polymorphic_derived2 : <link>static:<build>no <target-os>linux:<linkflags>-ldl ]
 
+        # Tests using shared libraries which are linked against static boost. Hence ignore for shared boost build
+        [ test-bsl-run test_multi_shared_lib : : multi_shared_1 multi_shared_2 : <link>shared:<build>no ]
         [ test-bsl-run test_private_ctor ]
         [ test-bsl-run test_reset_object_address : A ]
         [ test-bsl-run test_void_cast ]

--- a/test/test_singleton_inherited.cpp
+++ b/test/test_singleton_inherited.cpp
@@ -1,0 +1,82 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton_inherited.cpp:
+// Test the singleton class for a "inherited" singleton (used as Foo:public singleton<Foo>)
+// This can be uses as singleton<Foo>::get_const_instance() OR Foo::get_const_instance()
+//
+// - is_destroyed returns false when singleton is active or uninitialized
+// - is_destroyed returns true when singleton is destructed
+// - the singleton is eventually destructed (no memory leak)
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_tools.hpp"
+#include <boost/serialization/singleton.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_TEST because:
+// a) destructors are called after program exit
+// b) This is intended to be used by shared libraries too which would then need their own report_errors call
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    ConstructionState state;
+private:
+    controller() {
+        state = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// A simple class that sets its construction state in the controller singleton
+struct Foo: boost::serialization::singleton<Foo>{
+    Foo(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        THROW_ON_FALSE(controller::getInstance().state == CS_UNINIT);
+        controller::getInstance().state = CS_INIT;
+    }
+    ~Foo() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().state == CS_INIT);
+        controller::getInstance().state = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    THROW_ON_FALSE(state == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<Foo>::is_destroyed());
+    THROW_ON_FALSE(Foo::is_destroyed());
+}
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    // Check if the singleton is alive and use it
+    BOOST_CHECK(!boost::serialization::singleton<Foo>::is_destroyed());
+    BOOST_CHECK(!Foo::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<Foo>::get_const_instance().i == 42);
+    BOOST_CHECK(Foo::get_const_instance().i == 42);
+    return EXIT_SUCCESS;
+}
+

--- a/test/test_singleton_plain.cpp
+++ b/test/test_singleton_plain.cpp
@@ -1,0 +1,78 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_singleton_plain.cpp:
+// Test the singleton class for a "plain" singleton (used as singleton<Foo>)
+//
+// - is_destroyed returns false when singleton is active or uninitialized
+// - is_destroyed returns true when singleton is destructed
+// - the singleton is eventually destructed (no memory leak)
+
+// (C) Copyright 2018 Alexander Grund
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "test_tools.hpp"
+#include <boost/serialization/singleton.hpp>
+#include <boost/preprocessor/stringize.hpp>
+#include <stdexcept>
+
+// Can't use BOOST_TEST because:
+// a) destructors are called after program exit
+// b) This is intended to be used by shared libraries too which would then need their own report_errors call
+// We halso have to disable the Wterminate warning as we call this from dtors
+// C++ will terminate the program in such cases which is OK here
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wterminate"
+#define THROW_ON_FALSE(cond) if(!(cond)) throw std::runtime_error(__FILE__ "(" BOOST_PP_STRINGIZE(__LINE__) ") Assertion failed: " #cond)
+
+// Enum to designate the state of the singletonized instances
+enum ConstructionState{CS_UNINIT, CS_INIT, CS_DESTROYED};
+
+// We need another singleton to check for the destruction of the singletons at program exit
+// We don't need all the magic for shared library anti-optimization and can keep it very simple
+struct controller{
+    static controller& getInstance(){
+        static controller instance;
+        return instance;
+    }
+    ConstructionState state;
+private:
+    controller() {
+        state = CS_UNINIT;
+    }
+    ~controller();
+};
+
+// A simple class that sets its construction state in the controller singleton
+struct Foo{
+    Foo(): i(42) {
+        // access controller singleton. Therefore controller will be constructed before this
+        THROW_ON_FALSE(controller::getInstance().state == CS_UNINIT);
+        controller::getInstance().state = CS_INIT;
+    }
+    ~Foo() {
+        // Because controller is constructed before this, it will be destructed AFTER this. Hence controller is still valid
+        THROW_ON_FALSE(controller::getInstance().state == CS_INIT);
+        controller::getInstance().state = CS_DESTROYED;
+    }
+    // Volatile to prevent compiler optimization from removing this
+    volatile int i;
+};
+
+controller::~controller() {
+    // If this fails, the singletons were not freed and memory is leaked
+    THROW_ON_FALSE(state == CS_DESTROYED);
+    // If this fails, then the destroyed flag is not set and one may use a deleted instance if relying on this flag
+    THROW_ON_FALSE(boost::serialization::singleton<Foo>::is_destroyed());
+}
+
+int
+test_main( int /* argc */, char* /* argv */[] )
+{
+    // Check if the singleton is alive and use it
+    BOOST_CHECK(!boost::serialization::singleton<Foo>::is_destroyed());
+
+    BOOST_CHECK(boost::serialization::singleton<Foo>::get_const_instance().i == 42);
+    return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
This supersedes #105 with a more minimal approach based on current develop. Reason: Current develop contains a change (https://github.com/boostorg/serialization/commit/e1893dd28c408bb25352596e2f91892b3d570164), which I deemed mislead and reverted in #105 (5248dee2528b32907003042da84c5f4d650c470e). Note that the PR predates that change!   
To have a smaller changeset this revert is not included here.

Additionally it includes the crash test #111 and the improved is_destroyed test #129 to show that this does indeed fix the problem. Those PRs should be merged first!

The actual fix is https://github.com/boostorg/serialization/commit/c2c6e63c3e72a731e3a64afd8c3549b08f69344f which does the following:  

When a plain singleton `Foo` is used ("plain"=="does not inherit from `singleton<Foo>`) the class `singleton<Foo>` is never instantiated. Hence it is never destroyed. But the `is_destroyed` check on the current develop relies on the destruction of `singleton<Foo>` so the flag is set to false. As that destruction does not happen the flag stays true although `Foo` was destroyed. Accessing it (via `singleton<Foo>::get_const_instance()`) will then access invalid memory and crash (see #111)

For this the indirection via the `detail::singleton_wrapper` is required, which also allows usage of `Foo` with a protected ctor, (which is recommended: One should not be able to do e.g. `Foo f;`)

Note: The alternative is to force all users (`T`) to inherit from `singleton<T>` with the additional advantage that copy construction/assignment can be forbidden in `singleton<>` to avoid even more potential misuses.

The 2nd fix commit removes the assertions on `is_destroyed` before it is runtime checked. Due to the runtime check the assertion is not required and unless one can truly and reliably fix the shared-library-issue the runtime check will be required to avoid the crash. Having the assertion in place might make someone assume the runtime check can be removed. Obviously the assertion **will** fail for #111 after  `is_destroyed` is fixed making it 2 reasons to remove.