### PR TITLE
Use uncaught_exceptions from Boost.Core to avoid C++17 warnings

### DIFF
--- a/include/boost/archive/impl/basic_text_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_oprimitive.ipp
@@ -10,13 +10,14 @@
 
 #include <cstddef> // NULL
 #include <algorithm> // std::copy
-#include <exception> // std::uncaught_exception
 #include <boost/config.hpp>
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{ 
     using ::size_t; 
 } // namespace std
 #endif
+
+#include <boost/core/uncaught_exceptions.hpp>
 
 #include <boost/archive/basic_text_oprimitive.hpp>
 
@@ -106,7 +107,7 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
 template<class OStream>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL
 basic_text_oprimitive<OStream>::~basic_text_oprimitive(){
-    if(std::uncaught_exception())
+    if(boost::core::uncaught_exceptions() > 0)
         return;
     os << std::endl;
 }

--- a/include/boost/archive/impl/xml_iarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_iarchive_impl.ipp
@@ -11,7 +11,6 @@
 #include <boost/config.hpp>
 #include <cstring> // memcpy
 #include <cstddef> // NULL
-#include <exception>
 
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{ 
@@ -34,6 +33,7 @@ namespace std{
 #include <boost/archive/dinkumware.hpp>
 #endif
 
+#include <boost/core/uncaught_exceptions.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 
 #include <boost/archive/xml_archive_exception.hpp>
@@ -189,7 +189,7 @@ xml_iarchive_impl<Archive>::xml_iarchive_impl(
 template<class Archive>
 BOOST_ARCHIVE_DECL
 xml_iarchive_impl<Archive>::~xml_iarchive_impl(){
-    if(std::uncaught_exception())
+    if(boost::core::uncaught_exceptions() > 0)
         return;
     if(0 == (this->get_flags() & no_header)){
         gimpl->windup(is);

--- a/include/boost/archive/impl/xml_oarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_oarchive_impl.ipp
@@ -10,7 +10,6 @@
 #include <iomanip>
 #include <algorithm> // std::copy
 #include <string>
-#include <exception>
 
 #include <cstring> // strlen
 #include <boost/config.hpp> // msvc 6.0 needs this to suppress warnings
@@ -20,6 +19,7 @@ namespace std{
 } // namespace std
 #endif
 
+#include <boost/core/uncaught_exceptions.hpp>
 #include <boost/archive/iterators/xml_escape.hpp>
 #include <boost/archive/iterators/ostream_iterator.hpp>
 
@@ -132,7 +132,7 @@ xml_oarchive_impl<Archive>::save_binary(const void *address, std::size_t count){
 template<class Archive>
 BOOST_ARCHIVE_DECL
 xml_oarchive_impl<Archive>::~xml_oarchive_impl(){
-    if(std::uncaught_exception())
+    if(boost::core::uncaught_exceptions() > 0)
         return;
     if(0 == (this->get_flags() & no_header))
         this->windup();

--- a/include/boost/archive/impl/xml_wiarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_wiarchive_impl.ipp
@@ -20,13 +20,13 @@ namespace std{
 
 #include <boost/assert.hpp>
 #include <algorithm> // std::copy
-#include <exception> // uncaught exception
 #include <boost/detail/workaround.hpp> // Dinkumware and RogueWave
 #if BOOST_WORKAROUND(BOOST_DINKUMWARE_STDLIB, == 1)
 #include <boost/archive/dinkumware.hpp>
 #endif
 
 #include <boost/io/ios_state.hpp>
+#include <boost/core/uncaught_exceptions.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 #include <boost/serialization/string.hpp>
 
@@ -176,7 +176,7 @@ xml_wiarchive_impl<Archive>::xml_wiarchive_impl(
 template<class Archive>
 BOOST_WARCHIVE_DECL
 xml_wiarchive_impl<Archive>::~xml_wiarchive_impl(){
-    if(std::uncaught_exception())
+    if(boost::core::uncaught_exceptions() > 0)
         return;
     if(0 == (this->get_flags() & no_header)){
         gimpl->windup(is);

--- a/include/boost/archive/impl/xml_woarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_woarchive_impl.ipp
@@ -13,7 +13,6 @@
 #include <string>
 #include <algorithm> // std::copy
 #include <locale>
-#include <exception>
 
 #include <cstring> // strlen
 #include <cstdlib> // mbtowc
@@ -31,6 +30,8 @@ namespace std{
     #endif
 } // namespace std
 #endif
+
+#include <boost/core/uncaught_exceptions.hpp>
 
 #include <boost/archive/xml_woarchive.hpp>
 #include <boost/archive/detail/utf8_codecvt_facet.hpp>
@@ -139,7 +140,7 @@ xml_woarchive_impl<Archive>::xml_woarchive_impl(
 template<class Archive>
 BOOST_WARCHIVE_DECL
 xml_woarchive_impl<Archive>::~xml_woarchive_impl(){
-    if(std::uncaught_exception())
+    if(boost::core::uncaught_exceptions() > 0)
         return;
     if(0 == (this->get_flags() & no_header)){
         os << L"</boost_serialization>";


### PR DESCRIPTION
In C++17, `std::uncaught_exception` is deprecated in favor of `std::uncaught_exceptions`. Use portable `uncaught_exceptions` implementation from Boost.Core, which is also available for C++03.

This is an alternative to https://github.com/boostorg/serialization/pull/84.