### PR TITLE
more robust setting of optional version

### DIFF
--- a/include/boost/serialization/optional.hpp
+++ b/include/boost/serialization/optional.hpp
@@ -96,12 +96,9 @@ void serialize(
     boost::serialization::split_free(ar, t, version);
 }
 
-template<class T>
-struct version<boost::optional<T> > {
-    BOOST_STATIC_CONSTANT(int, value = 1);
-};
-
 } // serialization
 } // boost
+
+BOOST_CLASS_VERSION(boost::optional< T >, 1)
 
 #endif // BOOST_SERIALIZATION_OPTIONAL_HPP_


### PR DESCRIPTION
I think it would be better to use the macro provided in version.hpp since otherwise the version<boost::optional<T>> struct is missing fields (e.g. tag).