### PR TITLE
Replace spurious forward declaration

### DIFF
--- a/include/boost/serialization/shared_ptr_helper.hpp
+++ b/include/boost/serialization/shared_ptr_helper.hpp
@@ -39,10 +39,10 @@ namespace boost {
 namespace serialization {
 
 #ifndef BOOST_NO_MEMBER_TEMPLATE_FRIENDS
-template<class Archive, template<class U> class SPT >
+template<class Archive, template<class> class SPT, class U >
 void load(
     Archive & ar,
-    SPT< class U > &t,
+    SPT< U > &t,
     const unsigned int file_version
 );
 #endif


### PR DESCRIPTION
Previously the forward declaration referred to a non-existing `class U`.

Note that the `class U` in the template parameter of the template parameter `SPT` was not the same as the `class U` in the `SPT<class U> &t`.

This wrong forward declaration causes issues with g++7 and g++8 in c++17 mode:
* https://stackoverflow.com/questions/54534047/eigen-matrix-boostserialization-c17
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84075
* http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1676