### PR TITLE
Minor CMake path changes

### DIFF
--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -95,12 +95,12 @@ endif()
 #
 
 set(Boost_DEBUG true)
-set(Boost_ADDRESS_MODEL 64 CACHE INTEGER "32/64 bits")
+set(Boost_ADDRESS_MODEL 64 CACHE STRING "32/64 bits")
 set(Boost_USE_STATIC_LIBS TRUE CACHE BOOL "Use static libraries")
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_DETAILED_FAILURE_MSG true)
 
-get_filename_component(BOOST_ROOT "../../.." ABSOLUTE)
+get_filename_component(BOOST_ROOT "../../../.." ABSOLUTE)
 string(CONCAT boost_headers ${BOOST_ROOT} "/boost")
 if(NOT IS_DIRECTORY ${boost_headers})
     message(FATAL_ERROR "BOOST_ROOT not found")


### PR DESCRIPTION
Pull request for the issue #152.

Minor CMake enhancements and fixes are about strict standard-compliant option type (```INTEGER``` -> ```STRING```) and path fixes for CMake project being built inside of boost superproject source tree.

Try it yourself. Clone ```https://github.com/boostorg/boost``` and ```cmake -G Xcode ${BOOST_ROOT}/libs/serialization/CMake``` from some directory. Without this minor fix, it leads me to the error like ```CMake Error at CMakeLists.txt:106 (message): BOOST_ROOT not found```