### PR TITLE
fix missing header and inverted ifdef

### DIFF
--- a/include/boost/serialization/throw_exception.hpp
+++ b/include/boost/serialization/throw_exception.hpp
@@ -17,8 +17,9 @@
 
 #include <boost/config.hpp>
 
-#ifndef BOOST_NO_EXCEPTIONS
+#ifdef BOOST_NO_EXCEPTIONS
 #include <exception>
+#include <boost/throw_exception.hpp>
 #endif
 
 namespace boost {


### PR DESCRIPTION
@glenfe asked me to support BOOST_NO_EXCEPTIONS in Boost.Histogram and thus I found this issue. The serialization version of throw_exception calls ::boost::throw_exception but didn't include the header <boost/throw_exception.hpp>, so it only worked by chance if that header was already included.