### PR TITLE
just forward throw_exception

### DIFF
--- a/include/boost/serialization/throw_exception.hpp
+++ b/include/boost/serialization/throw_exception.hpp
@@ -15,28 +15,14 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/config.hpp>
-
-#ifndef BOOST_NO_EXCEPTIONS
-#include <exception>
-#endif
+#include <boost/throw_exception.hpp>
 
 namespace boost {
 namespace serialization {
 
-#ifdef BOOST_NO_EXCEPTIONS
-
-BOOST_NORETURN inline void throw_exception(std::exception const & e) {
+template<class E> BOOST_NORETURN inline void throw_exception(E const & e){
     ::boost::throw_exception(e);
 }
-
-#else
-
-template<class E> BOOST_NORETURN inline void throw_exception(E const & e){
-    throw e;
-}
-
-#endif
 
 } // namespace serialization
 } // namespace boost


### PR DESCRIPTION
This very simple implementation fixes the problem I have in Boost.Histogram when I try to compile my unit tests which use Boost.Serialization with `<exception-handling>off`. It also simplifies this code. `boost::serialization::throw_exception` is just forwarded to `boost::throw_exception`, which already calls `throw` if BOOST_NO_EXCEPTION is not defined and a user-defined `throw_exception` function otherwise.