### PR TITLE
"reference binding to null pointer" results in an undefined behaviour

### DIFF
--- a/include/boost/serialization/singleton.hpp
+++ b/include/boost/serialization/singleton.hpp
@@ -178,7 +178,7 @@ private:
         // Unfortunately, this triggers detectors of undefine behavior
         // and reports an error.  But I've been unable to find a different
         // of guarenteeing that the the singleton is created at pre-main time.
-        use(* m_instance);
+        if (m_instance) use(* m_instance);
 
         return static_cast<T &>(t);
     }


### PR DESCRIPTION
As shown in the following picture, the 181-th line in `singleton.hpp` triggers UndefinedBehaviourSanitizer. 

https://imgur.com/a/1998FjL