### PR TITLE
Use make_nvp from Core

### DIFF
--- a/include/boost/serialization/nvp.hpp
+++ b/include/boost/serialization/nvp.hpp
@@ -40,11 +40,7 @@ namespace boost {
 namespace serialization {
 
 using boost::nvp;
-
-template<class T>
-const nvp< T > make_nvp(const char * name, T & t){
-    return nvp< T >(name, t);
-}
+using boost::make_nvp;
 
 template<class Archive, class T>
 void save(


### PR DESCRIPTION
After this is merged this, we will update Core so that `make_nvp` is also defined in namespace `boost::serialization`.