### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/archive/archive_exception.hpp
+++ b/include/boost/archive/archive_exception.hpp
@@ -52,7 +52,7 @@ protected:
 public:
     typedef enum {
         no_exception,       // initialized without code
-        other_exception,    // any excepton not listed below
+        other_exception,    // any exception not listed below
         unregistered_class, // attempt to serialize a pointer of
                             // an unregistered class
         invalid_signature,  // first line of archive does not contain
@@ -63,7 +63,7 @@ public:
                             // serialize an object which has
                             // already been serialized through a pointer.
                             // Were this permitted, the archive load would result
-                            // in the creation of an extra copy of the obect.
+                            // in the creation of an extra copy of the object.
         incompatible_native_format, // attempt to read native binary format
                             // on incompatible platform
         array_size_too_short,// array being loaded doesn't fit in array allocated
@@ -87,9 +87,9 @@ public:
         const char * e1 = NULL,
         const char * e2 = NULL
     ) BOOST_NOEXCEPT;
-    BOOST_ARCHIVE_DECL archive_exception(archive_exception const &) BOOST_NOEXCEPT ;
-    virtual BOOST_ARCHIVE_DECL ~archive_exception() BOOST_NOEXCEPT_OR_NOTHROW ;
-    virtual BOOST_ARCHIVE_DECL const char * what() const BOOST_NOEXCEPT_OR_NOTHROW ;
+    BOOST_ARCHIVE_DECL archive_exception(archive_exception const &) BOOST_NOEXCEPT;
+    BOOST_ARCHIVE_DECL ~archive_exception() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
+    BOOST_ARCHIVE_DECL const char * what() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
 };
 
 }// namespace archive

--- a/include/boost/archive/basic_archive.hpp
+++ b/include/boost/archive/basic_archive.hpp
@@ -42,7 +42,7 @@ private:
     typedef uint_least16_t base_type;
     base_type t;
 public:
-    library_version_type(): t(0) {};
+    library_version_type(): t(0) {}
     explicit library_version_type(const unsigned int & t_) : t(t_){
         BOOST_ASSERT(t_ <= boost::integer_traits<base_type>::const_max);
     }
@@ -78,7 +78,7 @@ private:
     base_type t;
 public:
     // should be private - but MPI fails if it's not!!!
-    version_type(): t(0) {};
+    version_type(): t(0) {}
     explicit version_type(const unsigned int & t_) : t(t_){
         BOOST_ASSERT(t_ <= boost::integer_traits<base_type>::const_max);
     }
@@ -111,7 +111,7 @@ private:
     base_type t;
 public:
     // should be private - but then can't use BOOST_STRONG_TYPE below
-    class_id_type() : t(0) {};
+    class_id_type() : t(0) {}
     explicit class_id_type(const int t_) : t(t_){
         BOOST_ASSERT(t_ <= boost::integer_traits<base_type>::const_max);
     }
@@ -149,11 +149,11 @@ private:
     typedef uint_least32_t base_type;
     base_type t;
 public:
-    object_id_type(): t(0) {};
+    object_id_type(): t(0) {}
     // note: presumes that size_t >= unsigned int.
     // use explicit cast to silence useless warning
     explicit object_id_type(const std::size_t & t_) : t(static_cast<base_type>(t_)){
-        // make quadriple sure that we haven't lost any real integer
+        // make quadruple sure that we haven't lost any real integer
         // precision
         BOOST_ASSERT(t_ <= boost::integer_traits<base_type>::const_max);
     }
@@ -188,16 +188,16 @@ struct tracking_type {
     bool t;
     explicit tracking_type(const bool t_ = false)
         : t(t_)
-    {};
+    {}
     tracking_type(const tracking_type & t_)
         : t(t_.t)
     {}
     operator bool () const {
         return t;
-    };
+    }
     operator bool & () {
         return t;
-    };
+    }
     tracking_type & operator=(const bool t_){
         t = t_;
         return *this;

--- a/include/boost/archive/basic_text_iarchive.hpp
+++ b/include/boost/archive/basic_text_iarchive.hpp
@@ -54,7 +54,7 @@ public:
 #else
 protected:
     #if BOOST_WORKAROUND(BOOST_MSVC, < 1500)
-        // for some inexplicable reason insertion of "class" generates compile erro
+        // for some inexplicable reason insertion of "class" generates compile error
         // on msvc 7.1
         friend detail::interface_iarchive<Archive>;
     #else
@@ -76,12 +76,12 @@ protected:
     load_override(class_name_type & t);
 
     BOOST_ARCHIVE_OR_WARCHIVE_DECL void
-    init(void);
+    init();
 
     basic_text_iarchive(unsigned int flags) :
         detail::common_iarchive<Archive>(flags)
     {}
-    ~basic_text_iarchive(){}
+    ~basic_text_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/basic_text_oarchive.hpp
+++ b/include/boost/archive/basic_text_oarchive.hpp
@@ -104,7 +104,7 @@ protected:
         detail::common_oarchive<Archive>(flags),
         delimiter(none)
     {}
-    ~basic_text_oarchive(){}
+    ~basic_text_oarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/basic_xml_iarchive.hpp
+++ b/include/boost/archive/basic_xml_iarchive.hpp
@@ -104,7 +104,7 @@ protected:
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
     basic_xml_iarchive(unsigned int flags);
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
-    ~basic_xml_iarchive();
+    ~basic_xml_iarchive() BOOST_OVERRIDE;
 };
 
 } // namespace archive

--- a/include/boost/archive/basic_xml_oarchive.hpp
+++ b/include/boost/archive/basic_xml_oarchive.hpp
@@ -123,7 +123,7 @@ protected:
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
     basic_xml_oarchive(unsigned int flags);
     BOOST_ARCHIVE_OR_WARCHIVE_DECL
-    ~basic_xml_oarchive();
+    ~basic_xml_oarchive() BOOST_OVERRIDE;
 };
 
 } // namespace archive

--- a/include/boost/archive/codecvt_null.hpp
+++ b/include/boost/archive/codecvt_null.hpp
@@ -52,21 +52,21 @@ class codecvt_null;
 template<>
 class codecvt_null<char> : public std::codecvt<char, char, std::mbstate_t>
 {
-    virtual bool do_always_noconv() const throw() {
+    bool do_always_noconv() const throw() BOOST_OVERRIDE {
         return true;
     }
 public:
     explicit codecvt_null(std::size_t no_locale_manage = 0) :
         std::codecvt<char, char, std::mbstate_t>(no_locale_manage)
     {}
-    virtual ~codecvt_null(){};
+    ~codecvt_null() BOOST_OVERRIDE {}
 };
 
 template<>
 class BOOST_WARCHIVE_DECL codecvt_null<wchar_t> :
     public std::codecvt<wchar_t, char, std::mbstate_t>
 {
-    virtual std::codecvt_base::result
+    std::codecvt_base::result
     do_out(
         std::mbstate_t & state,
         const wchar_t * first1,
@@ -75,8 +75,8 @@ class BOOST_WARCHIVE_DECL codecvt_null<wchar_t> :
         char * first2,
         char * last2,
         char * & next2
-    ) const;
-    virtual std::codecvt_base::result
+    ) const BOOST_OVERRIDE;
+    std::codecvt_base::result
     do_in(
         std::mbstate_t & state,
         const char * first1,
@@ -85,11 +85,11 @@ class BOOST_WARCHIVE_DECL codecvt_null<wchar_t> :
         wchar_t * first2,
         wchar_t * last2,
         wchar_t * & next2
-    ) const;
-    virtual int do_encoding( ) const throw( ){
+    ) const BOOST_OVERRIDE;
+    int do_encoding( ) const throw( ) BOOST_OVERRIDE {
         return sizeof(wchar_t) / sizeof(char);
     }
-    virtual int do_max_length( ) const throw( ){
+    int do_max_length( ) const throw( ) BOOST_OVERRIDE {
         return do_encoding();
     }
 public:

--- a/include/boost/archive/detail/common_iarchive.hpp
+++ b/include/boost/archive/detail/common_iarchive.hpp
@@ -42,22 +42,22 @@ class BOOST_SYMBOL_VISIBLE common_iarchive :
     friend class interface_iarchive<Archive>;
     friend class basic_iarchive;
 private:
-    virtual void vload(version_type & t){
+    void vload(version_type & t) BOOST_OVERRIDE {
         * this->This() >> t;
     }
-    virtual void vload(object_id_type & t){
+    void vload(object_id_type & t) BOOST_OVERRIDE {
         * this->This() >> t;
     }
-    virtual void vload(class_id_type & t){
+    void vload(class_id_type & t) BOOST_OVERRIDE {
         * this->This() >> t;
     }
-    virtual void vload(class_id_optional_type & t){
+    void vload(class_id_optional_type & t) BOOST_OVERRIDE {
         * this->This() >> t;
     }
-    virtual void vload(tracking_type & t){
+    void vload(tracking_type & t) BOOST_OVERRIDE {
         * this->This() >> t;
     }
-    virtual void vload(class_name_type &s){
+    void vload(class_name_type &s) BOOST_OVERRIDE {
         * this->This() >> s;
     }
 protected:
@@ -86,4 +86,3 @@ protected:
 #endif
 
 #endif // BOOST_ARCHIVE_DETAIL_COMMON_IARCHIVE_HPP
-

--- a/include/boost/archive/detail/common_oarchive.hpp
+++ b/include/boost/archive/detail/common_oarchive.hpp
@@ -40,28 +40,28 @@ class BOOST_SYMBOL_VISIBLE common_oarchive :
     friend class interface_oarchive<Archive>;
     friend class basic_oarchive;
 private:
-    virtual void vsave(const version_type t){
+    void vsave(const version_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const object_id_type t){
+    void vsave(const object_id_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const object_reference_type t){
+    void vsave(const object_reference_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const class_id_type t){
+    void vsave(const class_id_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const class_id_reference_type t){
+    void vsave(const class_id_reference_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const class_id_optional_type t){
+    void vsave(const class_id_optional_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const class_name_type & t){
+    void vsave(const class_name_type & t) BOOST_OVERRIDE {
         * this->This() << t;
     }
-    virtual void vsave(const tracking_type t){
+    void vsave(const tracking_type t) BOOST_OVERRIDE {
         * this->This() << t;
     }
 protected:

--- a/include/boost/archive/detail/interface_iarchive.hpp
+++ b/include/boost/archive/detail/interface_iarchive.hpp
@@ -34,7 +34,7 @@ template<class Archive>
 class interface_iarchive
 {
 protected:
-    interface_iarchive(){};
+    interface_iarchive() {}
 public:
     /////////////////////////////////////////////////////////
     // archive public interface

--- a/include/boost/archive/detail/interface_oarchive.hpp
+++ b/include/boost/archive/detail/interface_oarchive.hpp
@@ -35,7 +35,7 @@ template<class Archive>
 class interface_oarchive
 {
 protected:
-    interface_oarchive(){};
+    interface_oarchive() {}
 public:
     /////////////////////////////////////////////////////////
     // archive public interface

--- a/include/boost/archive/detail/iserializer.hpp
+++ b/include/boost/archive/detail/iserializer.hpp
@@ -120,7 +120,7 @@ template<class Archive, class T>
 class iserializer : public basic_iserializer
 {
 private:
-    virtual void destroy(/*const*/ void *address) const {
+    void destroy(/*const*/ void *address) const BOOST_OVERRIDE {
         boost::serialization::access::destroy(static_cast<T *>(address));
     }
 public:
@@ -132,29 +132,29 @@ public:
             >::get_const_instance()
         )
     {}
-    virtual BOOST_DLLEXPORT void load_object_data(
+    BOOST_DLLEXPORT void load_object_data(
         basic_iarchive & ar,
         void *x,
         const unsigned int file_version
-    ) const BOOST_USED;
-    virtual bool class_info() const {
+    ) const BOOST_OVERRIDE BOOST_USED;
+    bool class_info() const BOOST_OVERRIDE {
         return boost::serialization::implementation_level< T >::value
             >= boost::serialization::object_class_info;
     }
-    virtual bool tracking(const unsigned int /* flags */) const {
+    bool tracking(const unsigned int /* flags */) const BOOST_OVERRIDE {
         return boost::serialization::tracking_level< T >::value
                 == boost::serialization::track_always
             || ( boost::serialization::tracking_level< T >::value
                 == boost::serialization::track_selectively
                 && serialized_as_pointer());
     }
-    virtual version_type version() const {
+    version_type version() const BOOST_OVERRIDE {
         return version_type(::boost::serialization::version< T >::value);
     }
-    virtual bool is_polymorphic() const {
+    bool is_polymorphic() const BOOST_OVERRIDE {
         return boost::is_polymorphic< T >::value;
     }
-    virtual ~iserializer(){};
+    ~iserializer() BOOST_OVERRIDE {}
 };
 
 #ifdef BOOST_MSVC
@@ -289,26 +289,26 @@ class pointer_iserializer :
     public basic_pointer_iserializer
 {
 private:
-    virtual void * heap_allocation() const {
+    void * heap_allocation() const BOOST_OVERRIDE {
         detail::heap_allocation<T> h;
         T * t = h.get();
         h.release();
         return t;
     }
-    virtual const basic_iserializer & get_basic_serializer() const {
+    const basic_iserializer & get_basic_serializer() const BOOST_OVERRIDE {
         return boost::serialization::singleton<
             iserializer<Archive, T>
         >::get_const_instance();
     }
-    BOOST_DLLEXPORT virtual void load_object_ptr(
+    BOOST_DLLEXPORT void load_object_ptr(
         basic_iarchive & ar,
         void * x,
         const unsigned int file_version
-    ) const BOOST_USED;
+    ) const BOOST_OVERRIDE BOOST_USED;
 public:
     // this should alway be a singleton so make the constructor protected
     pointer_iserializer();
-    ~pointer_iserializer();
+    ~pointer_iserializer() BOOST_OVERRIDE;
 };
 
 #ifdef BOOST_MSVC
@@ -573,7 +573,7 @@ struct load_array_type {
 
         // convert integers to correct enum to load
         // determine number of elements in the array. Consider the
-        // fact that some machines will align elements on boundries
+        // fact that some machines will align elements on boundaries
         // other than characters.
         std::size_t current_count = sizeof(t) / (
             static_cast<char *>(static_cast<void *>(&t[1]))

--- a/include/boost/archive/detail/oserializer.hpp
+++ b/include/boost/archive/detail/oserializer.hpp
@@ -116,26 +116,26 @@ public:
             >::get_const_instance()
         )
     {}
-    virtual BOOST_DLLEXPORT void save_object_data(
+    BOOST_DLLEXPORT void save_object_data(
         basic_oarchive & ar,
         const void *x
-    ) const BOOST_USED;
-    virtual bool class_info() const {
+    ) const BOOST_OVERRIDE BOOST_USED;
+    bool class_info() const BOOST_OVERRIDE {
         return boost::serialization::implementation_level< T >::value
             >= boost::serialization::object_class_info;
     }
-    virtual bool tracking(const unsigned int /* flags */) const {
+    bool tracking(const unsigned int /* flags */) const BOOST_OVERRIDE {
         return boost::serialization::tracking_level< T >::value == boost::serialization::track_always
             || (boost::serialization::tracking_level< T >::value == boost::serialization::track_selectively
                 && serialized_as_pointer());
     }
-    virtual version_type version() const {
+    version_type version() const BOOST_OVERRIDE {
         return version_type(::boost::serialization::version< T >::value);
     }
-    virtual bool is_polymorphic() const {
+    bool is_polymorphic() const BOOST_OVERRIDE {
         return boost::is_polymorphic< T >::value;
     }
-    virtual ~oserializer(){}
+    ~oserializer() BOOST_OVERRIDE {}
 };
 
 #ifdef BOOST_MSVC
@@ -168,18 +168,18 @@ class pointer_oserializer :
 {
 private:
     const basic_oserializer &
-    get_basic_serializer() const {
+    get_basic_serializer() const BOOST_OVERRIDE {
         return boost::serialization::singleton<
             oserializer<Archive, T>
         >::get_const_instance();
     }
-    virtual BOOST_DLLEXPORT void save_object_ptr(
+    BOOST_DLLEXPORT void save_object_ptr(
         basic_oarchive & ar,
         const void * x
-    ) const BOOST_USED;
+    ) const BOOST_OVERRIDE BOOST_USED;
 public:
     pointer_oserializer();
-    ~pointer_oserializer();
+    ~pointer_oserializer() BOOST_OVERRIDE;
 };
 
 #ifdef BOOST_MSVC

--- a/include/boost/archive/detail/polymorphic_iarchive_route.hpp
+++ b/include/boost/archive/detail/polymorphic_iarchive_route.hpp
@@ -56,125 +56,125 @@ class polymorphic_iarchive_route :
 {
 private:
     // these are used by the serialization library.
-    virtual void load_object(
+    void load_object(
         void *t,
         const basic_iserializer & bis
-    ){
+    ) BOOST_OVERRIDE {
         ArchiveImplementation::load_object(t, bis);
     }
-    virtual const basic_pointer_iserializer * load_pointer(
+    const basic_pointer_iserializer * load_pointer(
         void * & t,
         const basic_pointer_iserializer * bpis_ptr,
         const basic_pointer_iserializer * (*finder)(
             const boost::serialization::extended_type_info & type
         )
-    ){
+    ) BOOST_OVERRIDE {
         return ArchiveImplementation::load_pointer(t, bpis_ptr, finder);
     }
-    virtual void set_library_version(library_version_type archive_library_version){
+    void set_library_version(library_version_type archive_library_version) BOOST_OVERRIDE {
         ArchiveImplementation::set_library_version(archive_library_version);
     }
-    virtual library_version_type get_library_version() const{
+    library_version_type get_library_version() const BOOST_OVERRIDE {
         return ArchiveImplementation::get_library_version();
     }
-    virtual unsigned int get_flags() const {
+    unsigned int get_flags() const BOOST_OVERRIDE {
         return ArchiveImplementation::get_flags();
     }
-    virtual void delete_created_pointers(){
+    void delete_created_pointers() BOOST_OVERRIDE {
         ArchiveImplementation::delete_created_pointers();
     }
-    virtual void reset_object_address(
+    void reset_object_address(
         const void * new_address,
         const void * old_address
-    ){
+    ) BOOST_OVERRIDE {
         ArchiveImplementation::reset_object_address(new_address, old_address);
     }
-    virtual void load_binary(void * t, std::size_t size){
+    void load_binary(void * t, std::size_t size) BOOST_OVERRIDE {
         ArchiveImplementation::load_binary(t, size);
     }
     // primitive types the only ones permitted by polymorphic archives
-    virtual void load(bool & t){
+    void load(bool & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(char & t){
+    void load(char & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(signed char & t){
+    void load(signed char & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(unsigned char & t){
+    void load(unsigned char & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #ifndef BOOST_NO_CWCHAR
     #ifndef BOOST_NO_INTRINSIC_WCHAR_T
-    virtual void load(wchar_t & t){
+    void load(wchar_t & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #endif
     #endif
-    virtual void load(short & t){
+    void load(short & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(unsigned short & t){
+    void load(unsigned short & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(int & t){
+    void load(int & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(unsigned int & t){
+    void load(unsigned int & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(long & t){
+    void load(long & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(unsigned long & t){
+    void load(unsigned long & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #if defined(BOOST_HAS_LONG_LONG)
-    virtual void load(boost::long_long_type & t){
+    void load(boost::long_long_type & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(boost::ulong_long_type & t){
+    void load(boost::ulong_long_type & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #elif defined(BOOST_HAS_MS_INT64)
-    virtual void load(__int64 & t){
+    void load(__int64 & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(unsigned __int64 & t){
+    void load(unsigned __int64 & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #endif
-    virtual void load(float & t){
+    void load(float & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(double & t){
+    void load(double & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
-    virtual void load(std::string & t){
+    void load(std::string & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #ifndef BOOST_NO_STD_WSTRING
-    virtual void load(std::wstring & t){
+    void load(std::wstring & t) BOOST_OVERRIDE {
         ArchiveImplementation::load(t);
     }
     #endif
     // used for xml and other tagged formats default does nothing
-    virtual void load_start(const char * name){
+    void load_start(const char * name) BOOST_OVERRIDE {
         ArchiveImplementation::load_start(name);
     }
-    virtual void load_end(const char * name){
+    void load_end(const char * name) BOOST_OVERRIDE {
         ArchiveImplementation::load_end(name);
     }
-    virtual void register_basic_serializer(const basic_iserializer & bis){
+    void register_basic_serializer(const basic_iserializer & bis) BOOST_OVERRIDE {
         ArchiveImplementation::register_basic_serializer(bis);
     }
-    virtual helper_collection &
-    get_helper_collection(){
+    helper_collection &
+    get_helper_collection() BOOST_OVERRIDE {
         return ArchiveImplementation::get_helper_collection();
     }
 public:
-    // this can't be inheriteded because they appear in mulitple
+    // this can't be inherited because they appear in multiple
     // parents
     typedef mpl::bool_<true> is_loading;
     typedef mpl::bool_<false> is_saving;
@@ -202,7 +202,7 @@ public:
     ) :
         ArchiveImplementation(is, flags)
     {}
-    virtual ~polymorphic_iarchive_route(){};
+    ~polymorphic_iarchive_route() BOOST_OVERRIDE {}
 };
 
 } // namespace detail

--- a/include/boost/archive/detail/polymorphic_oarchive_route.hpp
+++ b/include/boost/archive/detail/polymorphic_oarchive_route.hpp
@@ -56,116 +56,116 @@ class polymorphic_oarchive_route :
 {
 private:
     // these are used by the serialization library.
-    virtual void save_object(
+    void save_object(
         const void *x,
         const detail::basic_oserializer & bos
-    ){
+    ) BOOST_OVERRIDE {
         ArchiveImplementation::save_object(x, bos);
     }
-    virtual void save_pointer(
+    void save_pointer(
         const void * t,
         const detail::basic_pointer_oserializer * bpos_ptr
-    ){
+    ) BOOST_OVERRIDE {
         ArchiveImplementation::save_pointer(t, bpos_ptr);
     }
-    virtual void save_null_pointer(){
+    void save_null_pointer() BOOST_OVERRIDE {
         ArchiveImplementation::save_null_pointer();
     }
     // primitive types the only ones permitted by polymorphic archives
-    virtual void save(const bool t){
+    void save(const bool t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const char t){
+    void save(const char t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const signed char t){
+    void save(const signed char t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const unsigned char t){
+    void save(const unsigned char t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #ifndef BOOST_NO_CWCHAR
     #ifndef BOOST_NO_INTRINSIC_WCHAR_T
-    virtual void save(const wchar_t t){
+    void save(const wchar_t t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #endif
     #endif
-    virtual void save(const short t){
+    void save(const short t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const unsigned short t){
+    void save(const unsigned short t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const int t){
+    void save(const int t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const unsigned int t){
+    void save(const unsigned int t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const long t){
+    void save(const long t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const unsigned long t){
+    void save(const unsigned long t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #if defined(BOOST_HAS_LONG_LONG)
-    virtual void save(const boost::long_long_type t){
+    void save(const boost::long_long_type t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const boost::ulong_long_type t){
+    void save(const boost::ulong_long_type t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #elif defined(BOOST_HAS_MS_INT64)
-    virtual void save(const boost::int64_t t){
+    void save(const boost::int64_t t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const boost::uint64_t t){
+    void save(const boost::uint64_t t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #endif
-    virtual void save(const float t){
+    void save(const float t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const double t){
+    void save(const double t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
-    virtual void save(const std::string & t){
+    void save(const std::string & t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #ifndef BOOST_NO_STD_WSTRING
-    virtual void save(const std::wstring & t){
+    void save(const std::wstring & t) BOOST_OVERRIDE {
         ArchiveImplementation::save(t);
     }
     #endif
-    virtual library_version_type get_library_version() const{
+    library_version_type get_library_version() const BOOST_OVERRIDE {
         return ArchiveImplementation::get_library_version();
     }
-    virtual unsigned int get_flags() const {
+    unsigned int get_flags() const BOOST_OVERRIDE {
         return ArchiveImplementation::get_flags();
     }
-    virtual void save_binary(const void * t, std::size_t size){
+    void save_binary(const void * t, std::size_t size) BOOST_OVERRIDE {
         ArchiveImplementation::save_binary(t, size);
     }
     // used for xml and other tagged formats default does nothing
-    virtual void save_start(const char * name){
+    void save_start(const char * name) BOOST_OVERRIDE {
         ArchiveImplementation::save_start(name);
     }
-    virtual void save_end(const char * name){
+    void save_end(const char * name) BOOST_OVERRIDE {
         ArchiveImplementation::save_end(name);
     }
-    virtual void end_preamble(){
+    void end_preamble() BOOST_OVERRIDE {
         ArchiveImplementation::end_preamble();
     }
-    virtual void register_basic_serializer(const detail::basic_oserializer & bos){
+    void register_basic_serializer(const detail::basic_oserializer & bos) BOOST_OVERRIDE {
         ArchiveImplementation::register_basic_serializer(bos);
     }
-    virtual helper_collection &
-    get_helper_collection(){
+    helper_collection &
+    get_helper_collection() BOOST_OVERRIDE {
         return ArchiveImplementation::get_helper_collection();
     }
 public:
-    // this can't be inheriteded because they appear in mulitple
+    // this can't be inherited because they appear in multiple
     // parents
     typedef mpl::bool_<false> is_loading;
     typedef mpl::bool_<true> is_saving;
@@ -193,7 +193,7 @@ public:
     ) :
         ArchiveImplementation(os, flags)
     {}
-    virtual ~polymorphic_oarchive_route(){};
+    ~polymorphic_oarchive_route() BOOST_OVERRIDE {}
 };
 
 } // namespace detail

--- a/include/boost/archive/impl/basic_binary_iarchive.ipp
+++ b/include/boost/archive/impl/basic_binary_iarchive.ipp
@@ -48,7 +48,7 @@ basic_binary_iarchive<Archive>::load_override(class_name_type & t){
 
 template<class Archive>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL void
-basic_binary_iarchive<Archive>::init(void){
+basic_binary_iarchive<Archive>::init() {
     // read signature in an archive version independent manner
     std::string file_signature;
     

--- a/include/boost/archive/impl/basic_text_iarchive.ipp
+++ b/include/boost/archive/impl/basic_text_iarchive.ipp
@@ -45,7 +45,7 @@ basic_text_iarchive<Archive>::load_override(class_name_type & t){
 
 template<class Archive>
 BOOST_ARCHIVE_OR_WARCHIVE_DECL void
-basic_text_iarchive<Archive>::init(void){
+basic_text_iarchive<Archive>::init() {
     // read signature in an archive version independent manner
     std::string file_signature;
     * this->This() >> file_signature;

--- a/include/boost/archive/impl/basic_xml_iarchive.ipp
+++ b/include/boost/archive/impl/basic_xml_iarchive.ipp
@@ -37,7 +37,6 @@ basic_xml_iarchive<Archive>::load_start(const char *name){
     }
     // don't check start tag at highest level
     ++depth;
-    return;
 }
 
 template<class Archive>

--- a/include/boost/archive/iterators/dataflow_exception.hpp
+++ b/include/boost/archive/iterators/dataflow_exception.hpp
@@ -46,7 +46,7 @@ public:
     dataflow_exception(exception_code c = other_exception) : code(c)
     {}
 
-    virtual const char *what( ) const throw( )
+    const char *what( ) const throw( ) BOOST_OVERRIDE
     {
         const char *msg = "unknown exception code";
         switch(code){

--- a/include/boost/archive/iterators/unescape.hpp
+++ b/include/boost/archive/iterators/unescape.hpp
@@ -71,7 +71,7 @@ private:
         ++(this->base_reference());
         dereference_impl();
         m_full = false;
-    };
+    }
 
 public:
 

--- a/include/boost/archive/polymorphic_binary_iarchive.hpp
+++ b/include/boost/archive/polymorphic_binary_iarchive.hpp
@@ -35,7 +35,7 @@ public:
     polymorphic_binary_iarchive(std::istream & is, unsigned int flags = 0) :
         detail::polymorphic_iarchive_route<binary_iarchive>(is, flags)
     {}
-    ~polymorphic_binary_iarchive(){}
+    ~polymorphic_binary_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -51,4 +51,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 )
 
 #endif // BOOST_ARCHIVE_POLYMORPHIC_BINARY_IARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_binary_oarchive.hpp
+++ b/include/boost/archive/polymorphic_binary_oarchive.hpp
@@ -30,7 +30,7 @@ public:
     polymorphic_binary_oarchive(std::ostream & os, unsigned int flags = 0) :
         detail::polymorphic_oarchive_route<binary_oarchive>(os, flags)
     {}
-    ~polymorphic_binary_oarchive(){}
+    ~polymorphic_binary_oarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -42,4 +42,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 )
 
 #endif // BOOST_ARCHIVE_POLYMORPHIC_BINARY_OARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_iarchive.hpp
+++ b/include/boost/archive/polymorphic_iarchive.hpp
@@ -116,7 +116,7 @@ public:
         load_end(t.name());
     }
 protected:
-    virtual ~polymorphic_iarchive_impl(){};
+    virtual ~polymorphic_iarchive_impl() {}
 public:
     // utility function implemented by all legal archives
     virtual void set_library_version(library_version_type archive_library_version) = 0;
@@ -156,7 +156,7 @@ class BOOST_SYMBOL_VISIBLE polymorphic_iarchive :
     public polymorphic_iarchive_impl
 {
 public:
-    virtual ~polymorphic_iarchive(){};
+    ~polymorphic_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/polymorphic_oarchive.hpp
+++ b/include/boost/archive/polymorphic_oarchive.hpp
@@ -118,7 +118,7 @@ public:
         save_end(t.name());
     }
 protected:
-    virtual ~polymorphic_oarchive_impl(){};
+    virtual ~polymorphic_oarchive_impl() {}
 public:
     // utility functions implemented by all legal archives
     virtual unsigned int get_flags() const = 0;
@@ -140,7 +140,7 @@ class BOOST_SYMBOL_VISIBLE polymorphic_oarchive :
     public polymorphic_oarchive_impl
 {
 public:
-    virtual ~polymorphic_oarchive(){};
+    ~polymorphic_oarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/polymorphic_text_iarchive.hpp
+++ b/include/boost/archive/polymorphic_text_iarchive.hpp
@@ -35,7 +35,7 @@ public:
     polymorphic_text_iarchive(std::istream & is, unsigned int flags = 0) :
         detail::polymorphic_iarchive_route<text_iarchive>(is, flags)
     {}
-    ~polymorphic_text_iarchive(){}
+    ~polymorphic_text_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -51,4 +51,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 )
 
 #endif // BOOST_ARCHIVE_POLYMORPHIC_TEXT_IARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_text_oarchive.hpp
+++ b/include/boost/archive/polymorphic_text_oarchive.hpp
@@ -30,7 +30,7 @@ public:
     polymorphic_text_oarchive(std::ostream & os, unsigned int flags = 0) :
         detail::polymorphic_oarchive_route<text_oarchive>(os, flags)
     {}
-    ~polymorphic_text_oarchive(){}
+    ~polymorphic_text_oarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -42,4 +42,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 )
 
 #endif // BOOST_ARCHIVE_POLYMORPHIC_TEXT_OARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_text_wiarchive.hpp
+++ b/include/boost/archive/polymorphic_text_wiarchive.hpp
@@ -39,7 +39,7 @@ public:
     polymorphic_text_wiarchive(std::wistream & is, unsigned int flags = 0) :
         detail::polymorphic_iarchive_route<text_wiarchive>(is, flags)
     {}
-    ~polymorphic_text_wiarchive(){}
+    ~polymorphic_text_wiarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -56,4 +56,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 
 #endif // BOOST_NO_STD_WSTREAMBUF
 #endif // BOOST_ARCHIVE_POLYMORPHIC_TEXT_WIARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_text_woarchive.hpp
+++ b/include/boost/archive/polymorphic_text_woarchive.hpp
@@ -34,7 +34,7 @@ public:
     polymorphic_text_woarchive(std::wostream & os, unsigned int flags = 0) :
         detail::polymorphic_oarchive_route<text_woarchive>(os, flags)
     {}
-    ~polymorphic_text_woarchive(){}
+    ~polymorphic_text_woarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -47,4 +47,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 
 #endif // BOOST_NO_STD_WSTREAMBUF
 #endif // BOOST_ARCHIVE_POLYMORPHIC_TEXT_WOARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_xml_iarchive.hpp
+++ b/include/boost/archive/polymorphic_xml_iarchive.hpp
@@ -35,7 +35,7 @@ public:
     polymorphic_xml_iarchive(std::istream & is, unsigned int flags = 0) :
         detail::polymorphic_iarchive_route<xml_iarchive>(is, flags)
     {}
-    ~polymorphic_xml_iarchive(){}
+    ~polymorphic_xml_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -51,4 +51,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 )
 
 #endif // BOOST_ARCHIVE_POLYMORPHIC_XML_IARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_xml_oarchive.hpp
+++ b/include/boost/archive/polymorphic_xml_oarchive.hpp
@@ -30,7 +30,7 @@ public:
     polymorphic_xml_oarchive(std::ostream & os, unsigned int flags = 0) :
         detail::polymorphic_oarchive_route<xml_oarchive>(os, flags)
     {}
-    ~polymorphic_xml_oarchive(){}
+    ~polymorphic_xml_oarchive() BOOST_OVERRIDE {}
 };
 } // namespace archive
 } // namespace boost
@@ -41,4 +41,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 )
 
 #endif // BOOST_ARCHIVE_POLYMORPHIC_XML_OARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_xml_wiarchive.hpp
+++ b/include/boost/archive/polymorphic_xml_wiarchive.hpp
@@ -34,7 +34,7 @@ public:
     polymorphic_xml_wiarchive(std::wistream & is, unsigned int flags = 0) :
         detail::polymorphic_iarchive_route<xml_wiarchive>(is, flags)
     {}
-    ~polymorphic_xml_wiarchive(){}
+    ~polymorphic_xml_wiarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -47,4 +47,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 
 #endif // BOOST_NO_STD_WSTREAMBUF
 #endif // BOOST_ARCHIVE_POLYMORPHIC_XML_WIARCHIVE_HPP
-

--- a/include/boost/archive/polymorphic_xml_woarchive.hpp
+++ b/include/boost/archive/polymorphic_xml_woarchive.hpp
@@ -34,7 +34,7 @@ public:
     polymorphic_xml_woarchive(std::wostream & os, unsigned int flags = 0) :
         detail::polymorphic_oarchive_route<xml_woarchive>(os, flags)
     {}
-    ~polymorphic_xml_woarchive(){}
+    ~polymorphic_xml_woarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -47,4 +47,3 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(
 
 #endif // BOOST_NO_STD_WSTREAMBUF
 #endif // BOOST_ARCHIVE_POLYMORPHIC_XML_WOARCHIVE_HPP
-

--- a/include/boost/archive/text_iarchive.hpp
+++ b/include/boost/archive/text_iarchive.hpp
@@ -89,7 +89,7 @@ protected:
     text_iarchive_impl(std::istream & is, unsigned int flags);
     // don't import inline definitions! leave this as a reminder.
     //BOOST_ARCHIVE_DECL
-    ~text_iarchive_impl(){};
+    ~text_iarchive_impl() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -119,7 +119,7 @@ public:
         if(0 == (flags & no_header))
              init();
     }
-    ~text_iarchive(){}
+    ~text_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/text_oarchive.hpp
+++ b/include/boost/archive/text_oarchive.hpp
@@ -86,14 +86,14 @@ protected:
     text_oarchive_impl(std::ostream & os, unsigned int flags);
     // don't import inline definitions! leave this as a reminder.
     //BOOST_ARCHIVE_DECL
-    ~text_oarchive_impl(){};
+    ~text_oarchive_impl() BOOST_OVERRIDE {}
 public:
     BOOST_ARCHIVE_DECL void
     save_binary(const void *address, std::size_t count);
 };
 
 // do not derive from this class.  If you want to extend this functionality
-// via inhertance, derived from text_oarchive_impl instead.  This will
+// via inheritance, derived from text_oarchive_impl instead.  This will
 // preserve correct static polymorphism.
 class BOOST_SYMBOL_VISIBLE text_oarchive :
     public text_oarchive_impl<text_oarchive>
@@ -106,7 +106,7 @@ public:
         if(0 == (flags & no_header))
             init();
     }
-    ~text_oarchive(){}
+    ~text_oarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/text_wiarchive.hpp
+++ b/include/boost/archive/text_wiarchive.hpp
@@ -94,7 +94,7 @@ protected:
     }
     BOOST_WARCHIVE_DECL
     text_wiarchive_impl(std::wistream & is, unsigned int flags);
-    ~text_wiarchive_impl(){};
+    ~text_wiarchive_impl() BOOST_OVERRIDE {}
 };
 
 } // namespace archive
@@ -123,7 +123,7 @@ public:
         if(0 == (flags & no_header))
             init();
     }
-    ~text_wiarchive(){}
+    ~text_wiarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/text_woarchive.hpp
+++ b/include/boost/archive/text_woarchive.hpp
@@ -124,7 +124,7 @@ public:
 // typedef text_oarchive_impl<text_oarchive_impl<...> > text_oarchive;
 
 // do not derive from this class.  If you want to extend this functionality
-// via inhertance, derived from text_oarchive_impl instead.  This will
+// via inheritance, derived from text_oarchive_impl instead.  This will
 // preserve correct static polymorphism.
 class BOOST_SYMBOL_VISIBLE text_woarchive :
     public text_woarchive_impl<text_woarchive>
@@ -136,7 +136,7 @@ public:
         if(0 == (flags & no_header))
             init();
     }
-    ~text_woarchive(){}
+    ~text_woarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/xml_archive_exception.hpp
+++ b/include/boost/archive/xml_archive_exception.hpp
@@ -45,8 +45,8 @@ public:
         const char * e1 = NULL,
         const char * e2 = NULL
     );
-    BOOST_ARCHIVE_DECL xml_archive_exception(xml_archive_exception const &) ;
-    virtual BOOST_ARCHIVE_DECL ~xml_archive_exception() BOOST_NOEXCEPT_OR_NOTHROW ;
+    BOOST_ARCHIVE_DECL xml_archive_exception(xml_archive_exception const &);
+    BOOST_ARCHIVE_DECL ~xml_archive_exception() BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE;
 };
 
 }// namespace archive

--- a/include/boost/archive/xml_iarchive.hpp
+++ b/include/boost/archive/xml_iarchive.hpp
@@ -101,7 +101,7 @@ protected:
     BOOST_ARCHIVE_DECL
     xml_iarchive_impl(std::istream & is, unsigned int flags);
     BOOST_ARCHIVE_DECL
-    ~xml_iarchive_impl();
+    ~xml_iarchive_impl() BOOST_OVERRIDE;
 };
 
 } // namespace archive
@@ -129,7 +129,7 @@ public:
         if(0 == (flags & no_header))
             init();
     }
-    ~xml_iarchive(){};
+    ~xml_iarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/xml_oarchive.hpp
+++ b/include/boost/archive/xml_oarchive.hpp
@@ -86,7 +86,7 @@ protected:
     BOOST_ARCHIVE_DECL
     xml_oarchive_impl(std::ostream & os, unsigned int flags);
     BOOST_ARCHIVE_DECL
-    ~xml_oarchive_impl();
+    ~xml_oarchive_impl() BOOST_OVERRIDE;
 public:
     BOOST_ARCHIVE_DECL
     void save_binary(const void *address, std::size_t count);
@@ -112,7 +112,7 @@ namespace archive {
 // typedef xml_oarchive_impl<xml_oarchive_impl<...> > xml_oarchive;
 
 // do not derive from this class.  If you want to extend this functionality
-// via inhertance, derived from xml_oarchive_impl instead.  This will
+// via inheritance, derived from xml_oarchive_impl instead.  This will
 // preserve correct static polymorphism.
 class BOOST_SYMBOL_VISIBLE xml_oarchive :
     public xml_oarchive_impl<xml_oarchive>
@@ -124,7 +124,7 @@ public:
         if(0 == (flags & no_header))
             init();
     }
-    ~xml_oarchive(){}
+    ~xml_oarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/xml_wiarchive.hpp
+++ b/include/boost/archive/xml_wiarchive.hpp
@@ -105,9 +105,9 @@ protected:
     BOOST_WARCHIVE_DECL void
     init();
     BOOST_WARCHIVE_DECL
-    xml_wiarchive_impl(std::wistream & is, unsigned int flags) ;
+    xml_wiarchive_impl(std::wistream & is, unsigned int flags);
     BOOST_WARCHIVE_DECL
-    ~xml_wiarchive_impl();
+    ~xml_wiarchive_impl() BOOST_OVERRIDE;
 };
 
 } // namespace archive
@@ -136,7 +136,7 @@ public:
     if(0 == (flags & no_header))
         init();
     }
-    ~xml_wiarchive(){}
+    ~xml_wiarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/archive/xml_woarchive.hpp
+++ b/include/boost/archive/xml_woarchive.hpp
@@ -95,7 +95,7 @@ protected:
     BOOST_WARCHIVE_DECL
     xml_woarchive_impl(std::wostream & os, unsigned int flags);
     BOOST_WARCHIVE_DECL
-    ~xml_woarchive_impl();
+    ~xml_woarchive_impl() BOOST_OVERRIDE;
 public:
     BOOST_WARCHIVE_DECL void
     save_binary(const void *address, std::size_t count);
@@ -106,7 +106,7 @@ public:
 // typedef xml_woarchive_impl<xml_woarchive_impl<...> > xml_woarchive;
 
 // do not derive from this class.  If you want to extend this functionality
-// via inhertance, derived from xml_woarchive_impl instead.  This will
+// via inheritance, derived from xml_woarchive_impl instead.  This will
 // preserve correct static polymorphism.
 class BOOST_SYMBOL_VISIBLE xml_woarchive :
     public xml_woarchive_impl<xml_woarchive>
@@ -118,7 +118,7 @@ public:
     if(0 == (flags & no_header))
         init();
     }
-    ~xml_woarchive(){}
+    ~xml_woarchive() BOOST_OVERRIDE {}
 };
 
 } // namespace archive

--- a/include/boost/serialization/extended_type_info_no_rtti.hpp
+++ b/include/boost/serialization/extended_type_info_no_rtti.hpp
@@ -57,12 +57,12 @@ class BOOST_SYMBOL_VISIBLE extended_type_info_no_rtti_0 :
 {
 protected:
     BOOST_SERIALIZATION_DECL extended_type_info_no_rtti_0(const char * key);
-    BOOST_SERIALIZATION_DECL ~extended_type_info_no_rtti_0();
+    BOOST_SERIALIZATION_DECL ~extended_type_info_no_rtti_0() BOOST_OVERRIDE;
 public:
-    virtual BOOST_SERIALIZATION_DECL bool
-    is_less_than(const boost::serialization::extended_type_info &rhs) const ;
-    virtual BOOST_SERIALIZATION_DECL bool
-    is_equal(const boost::serialization::extended_type_info &rhs) const ;
+    BOOST_SERIALIZATION_DECL bool
+    is_less_than(const boost::serialization::extended_type_info &rhs) const BOOST_OVERRIDE;
+    BOOST_SERIALIZATION_DECL bool
+    is_equal(const boost::serialization::extended_type_info &rhs) const BOOST_OVERRIDE;
 };
 
 } // no_rtti_system
@@ -103,7 +103,7 @@ public:
     {
         key_register();
     }
-    ~extended_type_info_no_rtti(){
+    ~extended_type_info_no_rtti() BOOST_OVERRIDE {
         key_unregister();
     }
     const extended_type_info *
@@ -112,7 +112,7 @@ public:
         // this implementation doesn't depend on typeid() but assumes
         // that the specified type has a function of the following signature.
         // A common implemention of such a function is to define as a virtual
-        // function. So if the is not a polymporphic type it's likely an error
+        // function. So if the is not a polymorphic type it's likely an error
         BOOST_STATIC_WARNING(boost::is_polymorphic< T >::value);
         const char * derived_key = t.get_key();
         BOOST_ASSERT(NULL != derived_key);
@@ -121,10 +121,10 @@ public:
     const char * get_key() const{
         return action<guid_defined< T >::value >::invoke();
     }
-    virtual const char * get_debug_info() const{
+    const char * get_debug_info() const BOOST_OVERRIDE {
         return action<guid_defined< T >::value >::invoke();
     }
-    virtual void * construct(unsigned int count, ...) const{
+    void * construct(unsigned int count, ...) const BOOST_OVERRIDE {
         // count up the arguments
         std::va_list ap;
         va_start(ap, count);
@@ -145,7 +145,7 @@ public:
             return NULL;
         }
     }
-    virtual void destroy(void const * const p) const{
+    void destroy(void const * const p) const BOOST_OVERRIDE {
         boost::serialization::access::destroy(
             static_cast<T const *>(p)
         );

--- a/include/boost/serialization/extended_type_info_typeid.hpp
+++ b/include/boost/serialization/extended_type_info_typeid.hpp
@@ -52,7 +52,7 @@ namespace typeid_system {
 class BOOST_SYMBOL_VISIBLE extended_type_info_typeid_0 :
     public extended_type_info
 {
-    virtual const char * get_debug_info() const {
+    const char * get_debug_info() const BOOST_OVERRIDE {
         if(static_cast<const std::type_info *>(0) == m_ti)
             return static_cast<const char *>(0);
         return m_ti->name();
@@ -60,16 +60,16 @@ class BOOST_SYMBOL_VISIBLE extended_type_info_typeid_0 :
 protected:
     const std::type_info * m_ti;
     BOOST_SERIALIZATION_DECL extended_type_info_typeid_0(const char * key);
-    BOOST_SERIALIZATION_DECL ~extended_type_info_typeid_0();
+    BOOST_SERIALIZATION_DECL ~extended_type_info_typeid_0() BOOST_OVERRIDE;
     BOOST_SERIALIZATION_DECL void type_register(const std::type_info & ti);
     BOOST_SERIALIZATION_DECL void type_unregister();
     BOOST_SERIALIZATION_DECL const extended_type_info *
     get_extended_type_info(const std::type_info & ti) const;
 public:
-    virtual BOOST_SERIALIZATION_DECL bool
-    is_less_than(const extended_type_info &rhs) const;
-    virtual BOOST_SERIALIZATION_DECL bool
-    is_equal(const extended_type_info &rhs) const;
+    BOOST_SERIALIZATION_DECL bool
+    is_less_than(const extended_type_info &rhs) const BOOST_OVERRIDE;
+    BOOST_SERIALIZATION_DECL bool
+    is_equal(const extended_type_info &rhs) const BOOST_OVERRIDE;
     const std::type_info & get_typeid() const {
         return *m_ti;
     }
@@ -91,7 +91,7 @@ public:
         type_register(typeid(T));
         key_register();
     }
-    ~extended_type_info_typeid(){
+    ~extended_type_info_typeid() BOOST_OVERRIDE {
         key_unregister();
         type_unregister();
     }
@@ -110,7 +110,7 @@ public:
     const char * get_key() const {
         return boost::serialization::guid< T >();
     }
-    virtual void * construct(unsigned int count, ...) const{
+    void * construct(unsigned int count, ...) const BOOST_OVERRIDE {
         // count up the arguments
         std::va_list ap;
         va_start(ap, count);
@@ -131,7 +131,7 @@ public:
             return NULL;
         }
     }
-    virtual void destroy(void const * const p) const {
+    void destroy(void const * const p) const BOOST_OVERRIDE {
         boost::serialization::access::destroy(
             static_cast<T const *>(p)
         );

--- a/include/boost/serialization/item_version_type.hpp
+++ b/include/boost/serialization/item_version_type.hpp
@@ -28,7 +28,7 @@ private:
     base_type t;
 public:
     // should be private - but MPI fails if it's not!!!
-    item_version_type(): t(0) {};
+    item_version_type(): t(0) {}
     explicit item_version_type(const unsigned int t_) : t(t_){
         BOOST_ASSERT(t_ <= boost::integer_traits<base_type>::const_max);
     }

--- a/include/boost/serialization/void_cast.hpp
+++ b/include/boost/serialization/void_cast.hpp
@@ -1,4 +1,4 @@
-#ifndef  BOOST_SERIALIZATION_VOID_CAST_HPP
+#ifndef BOOST_SERIALIZATION_VOID_CAST_HPP
 #define BOOST_SERIALIZATION_VOID_CAST_HPP
 
 // MS compatible compilers support #pragma once
@@ -122,7 +122,7 @@ public:
     // member extended type info records - NOT their
     // addresses.  This is necessary in order for the
     // void cast operations to work across dll and exe
-    // module boundries.
+    // module boundaries.
     bool operator<(const void_caster & rhs) const;
 
     const void_caster & operator*(){
@@ -155,26 +155,26 @@ template <class Derived, class Base>
 class BOOST_SYMBOL_VISIBLE void_caster_primitive :
     public void_caster
 {
-    virtual void const * downcast(void const * const t) const {
+    void const * downcast(void const * const t) const BOOST_OVERRIDE {
         const Derived * d =
             boost::serialization::smart_cast<const Derived *, const Base *>(
                 static_cast<const Base *>(t)
             );
         return d;
     }
-    virtual void const * upcast(void const * const t) const {
+    void const * upcast(void const * const t) const BOOST_OVERRIDE {
         const Base * b =
             boost::serialization::smart_cast<const Base *, const Derived *>(
                 static_cast<const Derived *>(t)
             );
         return b;
     }
-    virtual bool has_virtual_base() const {
+    bool has_virtual_base() const BOOST_OVERRIDE {
         return false;
     }
 public:
     void_caster_primitive();
-    virtual ~void_caster_primitive();
+    ~void_caster_primitive() BOOST_OVERRIDE;
 
 private:
     static std::ptrdiff_t base_offset() {
@@ -206,18 +206,18 @@ template <class Derived, class Base>
 class BOOST_SYMBOL_VISIBLE void_caster_virtual_base :
     public void_caster
 {
-    virtual bool has_virtual_base() const {
+    bool has_virtual_base() const BOOST_OVERRIDE {
         return true;
     }
 public:
-    virtual void const * downcast(void const * const t) const {
+    void const * downcast(void const * const t) const BOOST_OVERRIDE {
         const Derived * d =
             dynamic_cast<const Derived *>(
                 static_cast<const Base *>(t)
             );
         return d;
     }
-    virtual void const * upcast(void const * const t) const {
+    void const * upcast(void const * const t) const BOOST_OVERRIDE {
         const Base * b =
             dynamic_cast<const Base *>(
                 static_cast<const Derived *>(t)
@@ -225,7 +225,7 @@ public:
         return b;
     }
     void_caster_virtual_base();
-    virtual ~void_caster_virtual_base();
+    ~void_caster_virtual_base() BOOST_OVERRIDE;
 };
 
 #ifdef BOOST_MSVC

--- a/src/basic_oarchive.cpp
+++ b/src/basic_oarchive.cpp
@@ -134,7 +134,7 @@ class basic_oarchive_impl {
     // keyed on object id
     std::set<object_id_type> stored_pointers;
 
-    // address of the most recent object serialized as a poiner
+    // address of the most recent object serialized as a pointer
     // whose data itself is now pending serialization
     const void * pending_object;
     const basic_oserializer * pending_bos;
@@ -179,28 +179,28 @@ basic_oarchive_impl::find(const serialization::extended_type_info & ti) const {
     class bosarg : 
         public basic_oserializer
     {
-        bool class_info() const {
+        bool class_info() const BOOST_OVERRIDE {
             BOOST_ASSERT(false); 
             return false;
         }
         // returns true if objects should be tracked
-        bool tracking(const unsigned int) const {
+        bool tracking(const unsigned int) const BOOST_OVERRIDE {
             BOOST_ASSERT(false);
             return false;
         }
         // returns class version
-        version_type version() const {
+        version_type version() const BOOST_OVERRIDE {
             BOOST_ASSERT(false);
             return version_type(0);
         }
         // returns true if this class is polymorphic
-        bool is_polymorphic() const{
+        bool is_polymorphic() const BOOST_OVERRIDE {
             BOOST_ASSERT(false);
             return false;
         }
         void save_object_data(      
             basic_oarchive & /*ar*/, const void * /*x*/
-        ) const {
+        ) const BOOST_OVERRIDE {
             BOOST_ASSERT(false);
         }
     public:
@@ -306,7 +306,6 @@ basic_oarchive_impl::save_object(
     // just save the object id
     ar.vsave(object_reference_type(oid));
     ar.end_preamble();
-    return;
 }
 
 // colle

--- a/src/extended_type_info.cpp
+++ b/src/extended_type_info.cpp
@@ -79,24 +79,24 @@ typedef std::multiset<const extended_type_info *, key_compare> ktmap;
 
 class extended_type_info_arg : public extended_type_info
 {
-    virtual bool
-    is_less_than(const extended_type_info & /*rhs*/) const {
+    bool
+    is_less_than(const extended_type_info & /*rhs*/) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return false;
-    };
-    virtual bool
-    is_equal(const extended_type_info & /*rhs*/) const {
+    }
+    bool
+    is_equal(const extended_type_info & /*rhs*/) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return false;
-    };
-    virtual const char * get_debug_info() const {
+    }
+    const char * get_debug_info() const BOOST_OVERRIDE {
         return get_key();
     }
-    virtual void * construct(unsigned int /*count*/, ...) const{
+    void * construct(unsigned int /*count*/, ...) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual void destroy(void const * const /*p*/) const {
+    void destroy(void const * const /*p*/) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
     }
 public:
@@ -104,8 +104,7 @@ public:
         extended_type_info(0, key)
     {}
 
-    ~extended_type_info_arg(){
-    }
+    ~extended_type_info_arg() BOOST_OVERRIDE {}
 };
 
 #ifdef BOOST_MSVC

--- a/src/extended_type_info_typeid.cpp
+++ b/src/extended_type_info_typeid.cpp
@@ -10,11 +10,11 @@
 //  See http://www.boost.org for updates, documentation, and revision history.
 
 #include <algorithm>
-#include <set>
-#include <boost/assert.hpp>
-#include <typeinfo>
 #include <cstddef> // NULL
+#include <set>
+#include <typeinfo>
 
+#include <boost/assert.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 
 // it marks our code with proper attributes as being exported when
@@ -105,12 +105,12 @@ extended_type_info_typeid_0::type_unregister()
 
             // remove all entries in map which corresponds to this type
             // make sure that we don't use any invalidated iterators
-            for(;;){
+            while(true){
                 const tkmap::iterator & it = x.find(this);
                 if(it == x.end())
                     break;
                 x.erase(it);
-            };
+            }
         }
     }
     m_ti = NULL;
@@ -125,23 +125,23 @@ extended_type_info_typeid_0::type_unregister()
 class extended_type_info_typeid_arg : 
     public extended_type_info_typeid_0
 {
-    virtual void * construct(unsigned int /*count*/, ...) const{
+    void * construct(unsigned int /*count*/, ...) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual void destroy(void const * const /*p*/) const {
+    void destroy(void const * const /*p*/) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
     }
 public:
     extended_type_info_typeid_arg(const std::type_info & ti) :
         extended_type_info_typeid_0(NULL)
     { 
-        // note absense of self register and key as this is used only as
+        // note absence of self register and key as this is used only as
         // search argument given a type_info reference and is not to 
         // be added to the map.
         m_ti = & ti;
     }
-    ~extended_type_info_typeid_arg(){
+    ~extended_type_info_typeid_arg() BOOST_OVERRIDE {
         m_ti = NULL;
     }
 };

--- a/src/void_cast.cpp
+++ b/src/void_cast.cpp
@@ -43,7 +43,7 @@ namespace void_cast_detail {
 // member extended type info records - NOT their
 // addresses.  This is necessary in order for the
 // void cast operations to work across dll and exe
-// module boundries.
+// module boundaries.
 bool void_caster::operator<(const void_caster & rhs) const {
     // include short cut to save time and eliminate
     // problems when when base class aren't virtual
@@ -87,14 +87,14 @@ class void_caster_shortcut : public void_caster
     vbc_downcast(
         void const * const t
     ) const;
-    virtual void const *
-    upcast(void const * const t) const{
+    void const *
+    upcast(void const * const t) const BOOST_OVERRIDE {
         if(m_includes_virtual_base)
             return vbc_upcast(t);
         return static_cast<const char *> ( t ) - m_difference;
     }
-    virtual void const *
-    downcast(void const * const t) const{
+    void const *
+    downcast(void const * const t) const BOOST_OVERRIDE {
         if(m_includes_virtual_base)
             return vbc_downcast(t);
         return static_cast<const char *> ( t ) + m_difference;
@@ -102,7 +102,7 @@ class void_caster_shortcut : public void_caster
     virtual bool is_shortcut() const {
         return true;
     }
-    virtual bool has_virtual_base() const {
+    bool has_virtual_base() const BOOST_OVERRIDE {
         return m_includes_virtual_base;
     }
 public:
@@ -118,7 +118,7 @@ public:
     {
         recursive_register(includes_virtual_base);
     }
-    virtual ~void_caster_shortcut(){
+    ~void_caster_shortcut() BOOST_OVERRIDE {
         recursive_unregister();
     }
 };
@@ -187,17 +187,17 @@ void_caster_shortcut::vbc_upcast(
 // just used as a search key
 class void_caster_argument : public void_caster
 {
-    virtual void const *
-    upcast(void const * const /*t*/) const {
+    void const *
+    upcast(void const * const /*t*/) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual void const *
-    downcast( void const * const /*t*/) const {
+    void const *
+    downcast( void const * const /*t*/) const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return NULL;
     }
-    virtual bool has_virtual_base() const {
+    bool has_virtual_base() const BOOST_OVERRIDE {
         BOOST_ASSERT(false);
         return false;
     }
@@ -208,7 +208,7 @@ public:
     ) :
         void_caster(derived, base)
     {}
-    virtual ~void_caster_argument(){};
+    ~void_caster_argument() BOOST_OVERRIDE {}
 };
 
 #ifdef BOOST_MSVC


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Fix Clang -Wextra-semi and Clang-tidy modernize-redundant-void-arg and readability-redundant-control-flow warnings.
Also fix some misspellings in comments.
