### PR TITLE
Update no_exceptions_support.hpp header location to avoid deprecated warnings

### DIFF
--- a/performance/peformance_array.cpp
+++ b/performance/peformance_array.cpp
@@ -26,7 +26,7 @@ namespace std{
 // just copy over the files from the test directory
 #include BOOST_PP_STRINGIZE(BOOST_ARCHIVE_TEST)
 
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 #include <boost/archive/archive_exception.hpp>
 
 #include <boost/serialization/nvp.hpp>

--- a/test/D.hpp
+++ b/test/D.hpp
@@ -19,7 +19,7 @@
 #include <cstddef> // NULL
 
 #include "test_tools.hpp"
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 #include <boost/serialization/throw_exception.hpp>
 #include <boost/serialization/split_member.hpp>
 

--- a/test/test_tools.hpp
+++ b/test/test_tools.hpp
@@ -23,7 +23,7 @@
 #ifndef BOOST_NO_EXCEPTION_STD_NAMESPACE
     #include <exception>
 #endif
-#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/core/no_exceptions_support.hpp>
 
 #if defined(UNDER_CE)
 


### PR DESCRIPTION
`boost/detail/no_exceptions_support.hpp` is deprecated and will be removed in a future release.
