### PR TITLE
fix compile error

### DIFF
--- a/include/boost/serialization/map.hpp
+++ b/include/boost/serialization/map.hpp
@@ -25,6 +25,7 @@
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/collection_size_type.hpp>
 #include <boost/serialization/item_version_type.hpp>
+#include <boost/serialization/library_version_type.hpp>
 #include <boost/serialization/detail/stack_constructor.hpp>
 
 #include <boost/serialization/utility.hpp>


### PR DESCRIPTION
This is fixes the missing include that causes upstream failures in Boost Histogram tests, see #207 