### PR TITLE
Add missing include

### DIFF
--- a/include/boost/serialization/hash_set.hpp
+++ b/include/boost/serialization/hash_set.hpp
@@ -23,6 +23,7 @@
 #include <boost/serialization/hash_collections_save_imp.hpp>
 #include <boost/serialization/hash_collections_load_imp.hpp>
 #include <boost/serialization/split_free.hpp>
+#include <boost/serialization/detail/stack_constructor.hpp>
 #include <boost/move/utility_core.hpp>
 
 namespace boost {


### PR DESCRIPTION
This patch allows the header to be built standalone, as part of clang C++ modules builds.