### PR TITLE
Correct build errors when building serialization with BOOST_NO_STD_LOCALE defined

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -84,12 +84,15 @@ SOURCES =
     void_cast
     xml_grammar
     xml_iarchive
-    xml_oarchive
     xml_archive_exception
     codecvt_null
-    utf8_codecvt_facet
  ;
-    
+
+SOURCES_HAS_STD_LOCALE = 
+    xml_oarchive
+    utf8_codecvt_facet
+;
+
 WSOURCES = 
     basic_text_wiprimitive
     basic_text_woprimitive
@@ -104,9 +107,49 @@ WSOURCES =
     polymorphic_xml_woarchive
 ;
 
+rule has-config-flag ( flag : properties * )
+{
+    if ( "<define>$(flag)" in $(properties) || "<define>$(flag)=1" in $(properties) )
+    {
+        return 1 ;
+    }
+    else
+    {
+        return ;
+    }
+}
+
+rule select-define-specific-sources ( properties * )
+{
+    local result ;
+    if ! [ has-config-flag BOOST_NO_STD_LOCALE : $(properties) ]
+    {
+        result += <source>$(SOURCES_HAS_STD_LOCALE).cpp ;
+    }
+
+    #ECHO additional sources $(result) ;
+
+    return $(result) ;
+}
+
+rule should-build-wserialization ( properties * )
+{
+    local result ;
+    if [ has-config-flag BOOST_NO_STD_LOCALE : $(properties) ]
+    {
+        result += <build>no ;
+    }
+
+    #ECHO should build wserialization $(result) ;
+
+    return $(result) ;
+}
+
 lib boost_serialization 
-    : $(SOURCES).cpp
-    : 
+    : ## sources ##
+     $(SOURCES).cpp
+    : ## requirements ##
+    <conditional>@select-define-specific-sources
     <toolset>msvc:<cxxflags>/Gy
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
@@ -121,7 +164,8 @@ lib boost_serialization
 
 lib boost_wserialization 
     : $(WSOURCES).cpp boost_serialization 
-    :     
+    : 
+    <conditional>@should-build-wserialization
     <toolset>msvc:<cxxflags>/Gy 
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS

--- a/include/boost/archive/impl/basic_text_iprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_iprimitive.ipp
@@ -112,8 +112,8 @@ basic_text_iprimitive<IStream>::basic_text_iprimitive(
 ) :
     is(is_),
     flags_saver(is_),
-    precision_saver(is_),
 #ifndef BOOST_NO_STD_LOCALE
+    precision_saver(is_),
     codecvt_null_facet(1),
     archive_locale(is.getloc(), & codecvt_null_facet),
     locale_saver(is)
@@ -125,6 +125,7 @@ basic_text_iprimitive<IStream>::basic_text_iprimitive(
     is_ >> std::noboolalpha;
 }
 #else
+    precision_saver(is_)
 {}
 #endif
 

--- a/include/boost/archive/impl/basic_text_oprimitive.ipp
+++ b/include/boost/archive/impl/basic_text_oprimitive.ipp
@@ -87,8 +87,8 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
 ) : 
     os(os_),
     flags_saver(os_),
-    precision_saver(os_),
 #ifndef BOOST_NO_STD_LOCALE
+    precision_saver(os_),
     codecvt_null_facet(1),
     archive_locale(os.getloc(), & codecvt_null_facet),
     locale_saver(os)
@@ -100,6 +100,7 @@ basic_text_oprimitive<OStream>::basic_text_oprimitive(
     os_ << std::noboolalpha;
 }
 #else
+    precision_saver(os_)
 {}
 #endif
 


### PR DESCRIPTION
basic_text_iprimitive.ipp and basic_text_oprimitive.ipp have obvious errors.
Some files included boost/archive/detail/utf8_codecvt_facet.hpp and their build ended with `wide char i/o not supported on this platform` error. This is due to this statement
```
#ifdef BOOST_NO_STD_WSTREAMBUF
#error "wide char i/o not supported on this platform"
#endif
```

BOOST_NO_STD_WSTREAMBUF is explicitly defined when BOOST_NO_STD_LOCALE is defined:
```
//
// We can't have a working std::wstreambuf if there is no std::locale:
//
#  if defined(BOOST_NO_STD_LOCALE) && !defined(BOOST_NO_STD_WSTREAMBUF)
#     define BOOST_NO_STD_WSTREAMBUF
#  endif
```

The solution is to remove all these files from build when BOOST_NO_STD_LOCALE is defined. In case of serialization lib 2 files are removed, in case of wserialization the entire module.
I've changed only the jam build, not cmake. I think cmake build will fail.