### PR TITLE
Guard MSVC pragmas from clang-cl

### DIFF
--- a/include/boost/archive/detail/check.hpp
+++ b/include/boost/archive/detail/check.hpp
@@ -4,8 +4,10 @@
 // MS compatible compilers support #pragma once
 #if defined(_MSC_VER)
 # pragma once
+#if !defined(__clang__)
 #pragma inline_depth(255)
 #pragma inline_recursion(on)
+#endif
 #endif
 
 #if defined(__MWERKS__)

--- a/include/boost/archive/detail/iserializer.hpp
+++ b/include/boost/archive/detail/iserializer.hpp
@@ -4,8 +4,10 @@
 // MS compatible compilers support #pragma once
 #if defined(BOOST_MSVC)
 # pragma once
+#if !defined(__clang__)
 #pragma inline_depth(255)
 #pragma inline_recursion(on)
+#endif
 #endif
 
 #if defined(__MWERKS__)

--- a/include/boost/archive/detail/oserializer.hpp
+++ b/include/boost/archive/detail/oserializer.hpp
@@ -4,8 +4,10 @@
 // MS compatible compilers support #pragma once
 #if defined(_MSC_VER)
 # pragma once
+#if !defined(__clang__)
 #pragma inline_depth(255)
 #pragma inline_recursion(on)
+#endif
 #endif
 
 #if defined(__MWERKS__)


### PR DESCRIPTION
This patch avoids the "unknown pragma" warnings from Clang-cl (Clang for Windows, b2 toolset=clang-win.)