### PR TITLE
Revert "changes made in the hope of eliminated “stable” error for fun…

### DIFF
--- a/include/boost/archive/codecvt_null.hpp
+++ b/include/boost/archive/codecvt_null.hpp
@@ -100,9 +100,10 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> :
         return do_encoding();
     }
 public:
-    BOOST_SYMBOL_EXPORT explicit codecvt_null(std::size_t no_locale_manage = 0);
-
-    BOOST_SYMBOL_EXPORT ~codecvt_null() BOOST_OVERRIDE ;
+    BOOST_SYMBOL_EXPORT explicit codecvt_null(std::size_t no_locale_manage = 0) :
+        std::codecvt<wchar_t, char, std::mbstate_t>(no_locale_manage)
+    {}
+    BOOST_SYMBOL_EXPORT ~codecvt_null() BOOST_OVERRIDE {};
 };
 
 } // namespace archive

--- a/include/boost/archive/detail/utf8_codecvt_facet.hpp
+++ b/include/boost/archive/detail/utf8_codecvt_facet.hpp
@@ -17,6 +17,7 @@
 #include <boost/archive/detail/decl.hpp>
 #define BOOST_UTF8_BEGIN_NAMESPACE \
      namespace boost { namespace archive { namespace detail {
+#define   BOOST_ARCHIVE_DECL
 #define BOOST_UTF8_END_NAMESPACE }}}
 
 #include <boost/detail/utf8_codecvt_facet.hpp>

--- a/src/codecvt_null.cpp
+++ b/src/codecvt_null.cpp
@@ -80,12 +80,5 @@ codecvt_null<wchar_t>::do_in(
     return std::codecvt_base::ok;
 }
 
-BOOST_SYMBOL_EXPORT codecvt_null<wchar_t>::codecvt_null(std::size_t no_locale_manage) :
-    std::codecvt<wchar_t, char, std::mbstate_t>(no_locale_manage)
-{}
-
-BOOST_SYMBOL_EXPORT codecvt_null<wchar_t>::~codecvt_null()
-{}
-
 } // namespace archive
 } // namespace boost


### PR DESCRIPTION
…ctions previously defined in the header.  Moved those function to codecvt_null.cpp"

This reverts commit 812ef99dea96a5b74de58df4c8437821908e5ae4. 
#232 