### PR TITLE
Fix mb_from_wchar copy constructor

### DIFF
--- a/include/boost/archive/iterators/mb_from_wchar.hpp
+++ b/include/boost/archive/iterators/mb_from_wchar.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/assert.hpp>
 #include <cstddef> // size_t
+#include <cstring> // memcpy
 #ifndef BOOST_NO_CWCHAR
 #include <cwchar> //  mbstate_t
 #endif
@@ -25,6 +26,7 @@
 #if defined(BOOST_NO_STDC_NAMESPACE)
 namespace std{
     using ::mbstate_t;
+    using ::memcpy;
 } // namespace std
 #endif
 
@@ -129,10 +131,13 @@ public:
     // intel 7.1 doesn't like default copy constructor
     mb_from_wchar(const mb_from_wchar & rhs) :
         super_t(rhs.base_reference()),
+        m_mbs(rhs.m_mbs),
         m_bend(rhs.m_bend),
         m_bnext(rhs.m_bnext),
         m_full(rhs.m_full)
-    {}
+    {
+        std::memcpy(m_buffer, rhs.m_buffer, sizeof(m_buffer));
+    }
 };
 
 } // namespace iterators


### PR DESCRIPTION
Now mb_from_wchar copy constructor does not copy all fields so a copy can work incorrectly.
If m_full is true after copying dereference_impl() will return garbage from m_buffer.
A problem is found with Svace static analyzer. It warned that m_mbs is not initialized in a constructor.

m_codecvt_facet is not copied but this is not a problem because all its methods are const.