### PR TITLE
Missing #include in throw_exception.hpp

### DIFF
--- a/include/boost/serialization/throw_exception.hpp
+++ b/include/boost/serialization/throw_exception.hpp
@@ -18,7 +18,7 @@
 #include <boost/config.hpp>
 
 #ifndef BOOST_NO_EXCEPTIONS
-#include <exception>
+#include <boost/throw_exception.hpp>
 #endif
 
 namespace boost {


### PR DESCRIPTION
boost/serialization/throw_exception.hpp does not include the header which defines boost::throw_exception leading to compiler errors unless that header just happens to be #included elsewhere.  See this message thread: https://lists.boost.org/boost-users/2022/01/91144.php

Likewise the std lib header <exception> is *not* required since we use nothing from that here.