### PR TITLE
Use rehash(count) instead of rehash(bucket_count), to avoid excessive pre-allocation.

### DIFF
--- a/include/boost/serialization/unordered_collections_load_imp.hpp
+++ b/include/boost/serialization/unordered_collections_load_imp.hpp
@@ -59,7 +59,12 @@ inline void load_unordered_collection(Archive & ar, Container &s)
         ar >> BOOST_SERIALIZATION_NVP(item_version);
     }
     s.clear();
-    s.rehash(bucket_count);
+    // rehash() will pre-allocate the appropriate number of buckets
+    // given the number of items to be inserted. Therefore it is
+    // unneccesary to use bucket_count here, especially when bucket_count
+    // may be much larger than what is neccessary for 'count' items.
+    //
+    s.rehash(count);
     InputFunction ifunc;
     while(count-- > 0){
         ifunc(ar, s, item_version);


### PR DESCRIPTION
On windows, the number of buckets in an unordered_map never decreases: https://godbolt.org/z/9jrMv6Gah
When an archive is saved, the bucket_count is the MAX that it ever was in that session, no matter what count is.
When that archive is loaded, even though count may be small, the rehash would allocate way more memory than is necessary.

This change solves that by using count for the rehash, which will pre-allocate the appropriate number of buckets, on each platform: https://godbolt.org/z/6fjfWGh47
