### PR TITLE
src/basic_archive.cpp: improve docs for archive version 19

### DIFF
--- a/src/basic_archive.cpp
+++ b/src/basic_archive.cpp
@@ -83,7 +83,7 @@ BOOST_ARCHIVE_SIGNATURE(){
 // 18- addressed undefined behavior in archive constructors.
 //     init() called from base wrote archive header before archive
 //     was fully constructed.
-//     Boost 1.76 
+// 19- Boost 1.76 April 2021
 
 BOOST_SYMBOL_VISIBLE boost::serialization::library_version_type
 BOOST_ARCHIVE_VERSION(){


### PR DESCRIPTION
The archive version was bumped for 18 to 19 without properly updating the table above.