### PR TITLE
Fix clang -Wdeprecated-copy warning when using -std=gnu++2b in boost/archive/detail/helper_collection.hpp

### DIFF
--- a/include/boost/archive/detail/helper_collection.hpp
+++ b/include/boost/archive/detail/helper_collection.hpp
@@ -55,6 +55,7 @@ class helper_collection
     collection m_collection;
 
     struct predicate {
+        BOOST_DEFAULTED_FUNCTION(predicate(const predicate& rhs), { m_ti = rhs.m_ti; })
         BOOST_DELETED_FUNCTION(predicate & operator=(const predicate & rhs))
     public:
         const void * const m_ti;


### PR DESCRIPTION
```
In file included from magadm/CmdGetInfoHTHSession.cpp:24:
In file included from /remote/users/mlamesch/CloneFromPlatinum/SI_Pack23-2/common/include/si/common/HTHSegmentationCacheInfoSerialization.h:19:
In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/archive/text_iarchive.hpp:24:
In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/archive/basic_text_iarchive.hpp:30:
In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/archive/detail/common_iarchive.hpp:21:
In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/archive/detail/basic_iarchive.hpp:28:
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/archive/detail/helper_collection.hpp:58:44: error: definition of implicit copy constructor for 'predicate' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
        BOOST_DELETED_FUNCTION(predicate & operator=(const predicate & rhs))
                                           ^
/opt/1A/toolchain/x86_64-v23.0.2/lib64/gcc/x86_64-1a-linux-gnu/13.0.0/../../../../include/c++/13.0.0/bits/predefined_ops.h:325:37: note: in implicit copy constructor for 'boost::archive::detail::helper_collection::predicate' first required here
    { return _Iter_pred<_Predicate>(_GLIBCXX_MOVE(__pred)); }
                                    ^
/opt/1A/toolchain/x86_64-v23.0.2/lib64/gcc/x86_64-1a-linux-gnu/13.0.0/../../../../include/c++/13.0.0/bits/move.h:167:30: note: expanded from macro '_GLIBCXX_MOVE'
                             ^
/opt/1A/toolchain/x86_64-v23.0.2/lib64/gcc/x86_64-1a-linux-gnu/13.0.0/../../../../include/c++/13.0.0/bits/stl_algo.h:3923:26: note: in instantiation of function template specialization '__gnu_cxx::__ops::__pred_iter<boost::archive::detail::helper_collection::predicate>' requested here
                            __gnu_cxx::__ops::__pred_iter(__pred));
                                              ^
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/archive/detail/helper_collection.hpp:75:18: note: in instantiation of function template specialization 'std::find_if<__gnu_cxx::__normal_iterator<std::pair<const void *, boost::shared_ptr<void>> *, std::vector<std::pair<const void *, boost::shared_ptr<void>>>>, boost::archive::detail::helper_collection::predicate>' requested here
            std::find_if(
                 ^
```