### PR TITLE
Declare non-ODR-used copy constructor

### DIFF
--- a/src/basic_oarchive.cpp
+++ b/src/basic_oarchive.cpp
@@ -68,13 +68,6 @@ class basic_oarchive_impl {
                 return false;
             return class_id < rhs.class_id;
         }
-        aobject & operator=(const aobject & rhs)
-        {
-            address = rhs.address;
-            class_id = rhs.class_id;
-            object_id = rhs.object_id;
-            return *this;
-        }
         aobject(
             const void *a,
             class_id_type class_id_,

--- a/src/basic_xml_grammar.ipp
+++ b/src/basic_xml_grammar.ipp
@@ -82,6 +82,9 @@ struct assign_impl<std::string> {
             ++b;
         }
     }
+    assign_impl(
+        const assign_impl<std::string> & rhs
+    );
     assign_impl<std::string> & operator=(
         assign_impl<std::string> & rhs
     );


### PR DESCRIPTION
The compiler-generated copy constructor is deprecated since C++11 on classes with user-declared copy assignment operator.

This change allows clean compilation with the -Wdeprecated-copy/-Wdeprecated-copy-with-user-provided-ctor flag.