### PR TITLE
Use containers to supported deprecated OS with GHA

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -1,3 +1,12 @@
+# Copyright 2020-2021 Peter Dimov
+# Copyright 2021 Andrey Semashev
+# Copyright 2021 Alexander Grund
+# Copyright 2022 James E. King III
+# Copyright 2023 Matt Borland
+#
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
 name: POSIX
 
 on:
@@ -8,9 +17,16 @@ on:
       - develop
       - feature/**
 
+concurrency:
+  group: ${{format('{0}:{1}', github.repository, github.ref)}}
+  cancel-in-progress: true
+
 env:
   LIBRARY: serialization
   UBSAN_OPTIONS: print_stacktrace=1
+  GIT_FETCH_JOBS: 8
+  NET_RETRY_COUNT: 5
+  DEFAULT_BUILD_VARIANT: release
 
 jobs:
   CI:
@@ -18,73 +34,463 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - toolset: gcc-4.6
+            cxxstd: "03"
+            address_model: 64
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - g++-4.6
+            sources:
+              - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.7
             cxxstd: "03,11"
-            os: ubuntu-18.04
-            install: g++-4.7
+            address_model: 64
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - g++-4.8
+            sources:
+              - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.8
             cxxstd: "03,11"
-            os: ubuntu-18.04
-            install: g++-4.8
+            address_model: 64
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - g++-4.8
+            sources:
+              - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.9
             cxxstd: "03,11"
-            os: ubuntu-18.04
-            install: g++-4.9
+            address_model: 64
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - g++-4.9
+            sources:
+              - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-5
             cxxstd: "03,11,14,1z"
-            os: ubuntu-18.04
+            address_model: 32,64
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - g++-5-multilib
+          - toolset: gcc-5
+            cxxstd: "03-gnu,11-gnu,14-gnu,1z-gnu"
+            address_model: 32,64
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - g++-5-multilib
           - toolset: gcc-6
             cxxstd: "03,11,14,1z"
-            os: ubuntu-18.04
-            install: g++-6
+            address_model: 32,64
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - g++-6-multilib
           - toolset: gcc-7
             cxxstd: "03,11,14,17"
-            os: ubuntu-18.04
-            install: g++-7
+            address_model: 32,64
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - g++-7-multilib
           - toolset: gcc-8
             cxxstd: "03,11,14,17,2a"
-            os: ubuntu-18.04
-            install: g++-8
+            address_model: 32,64
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - g++-8-multilib
           - toolset: gcc-9
             cxxstd: "03,11,14,17,2a"
-            os: ubuntu-18.04
-            install: g++-9
+            address_model: 32,64
+            os: ubuntu-20.04
+            install:
+              - g++-9-multilib
+          - toolset: gcc-9
+            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,2a-gnu"
+            address_model: 32,64
+            os: ubuntu-20.04
+            install:
+              - g++-9-multilib
           - toolset: gcc-10
-            cxxstd: "03,11,14,17,2a"
-            os: ubuntu-18.04
-            install: g++-10
-          - toolset: clang
-            cxxstd: "03,11,14,17,2a"
-            os: ubuntu-18.04
-            install: clang
-          - toolset: clang
-            cxxstd: "03,11,14,17,2a"
-            os: macos-10.15
-            install: clang
+            cxxstd: "03,11,14,17,20"
+            address_model: 32,64
+            os: ubuntu-20.04
+            install:
+              - g++-10-multilib
+          - toolset: gcc-11
+            cxxstd: "03,11,14,17,20,23"
+            address_model: 32,64
+            os: ubuntu-22.04
+            install:
+              - g++-11-multilib
+          - toolset: gcc-12
+            cxxstd: "03,11,14,17,20,23"
+            address_model: 32,64
+            os: ubuntu-22.04
+            install:
+              - g++-12-multilib
+          - toolset: gcc-12
+            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu,23-gnu"
+            address_model: 32,64
+            os: ubuntu-22.04
+            install:
+              - g++-12-multilib
+          - name: UBSAN
+            toolset: gcc-12
+            cxxstd: "03,11,14,17,20,23"
+            address_model: 32,64
+            ubsan: 1
+            os: ubuntu-22.04
+            install:
+              - g++-12-multilib
 
+          # Linux, clang
+          - toolset: clang
+            compiler: clang++-3.7
+            cxxstd: "03,11,14"
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - clang-3.7
+          - toolset: clang
+            compiler: clang++-3.8
+            cxxstd: "03,11,14"
+            os: ubuntu-latest
+            container: ubuntu:16.04
+            install:
+              - clang-3.8
+          - toolset: clang
+            compiler: clang++-3.9
+            cxxstd: "03,11,14"
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - clang-3.9
+          - toolset: clang
+            compiler: clang++-4.0
+            cxxstd: "03,11,14"
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - clang-4.0
+          - toolset: clang
+            compiler: clang++-5.0
+            cxxstd: "03,11,14,1z"
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - clang-5.0
+          - toolset: clang
+            compiler: clang++-6.0
+            cxxstd: "03,11,14,17"
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - clang-6.0
+          - toolset: clang
+            compiler: clang++-7
+            cxxstd: "03,11,14,17"
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - clang-7
+          # Note: clang-8 does not fully support C++20, so it is not compatible with libstdc++-8 in this mode
+          - toolset: clang
+            compiler: clang++-8
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-latest
+            container: ubuntu:18.04
+            install:
+              - clang-8
+              - g++-7
+            gcc_toolchain: 7
+          - toolset: clang
+            compiler: clang++-9
+            cxxstd: "03,11,14,17,2a"
+            os: ubuntu-20.04
+            install:
+              - clang-9
+          - toolset: clang
+            compiler: clang++-10
+            cxxstd: "03,11,14,17,20"
+            os: ubuntu-20.04
+            install:
+              - clang-10
+          - toolset: clang
+            compiler: clang++-11
+            cxxstd: "03,11,14,17,20"
+            os: ubuntu-22.04
+            install:
+              - clang-11
+          - toolset: clang
+            compiler: clang++-12
+            cxxstd: "03,11,14,17,20,2b"
+            os: ubuntu-22.04
+            install:
+              - clang-12
+          - toolset: clang
+            compiler: clang++-13
+            cxxstd: "03,11,14,17,20,2b"
+            os: ubuntu-22.04
+            install:
+              - clang-13
+          - toolset: clang
+            compiler: clang++-14
+            cxxstd: "03,11,14,17,20,2b"
+            os: ubuntu-22.04
+            install:
+              - clang-14
+          - toolset: clang
+            compiler: clang++-14
+            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu,2b-gnu"
+            os: ubuntu-22.04
+            install:
+              - clang-14
+          - toolset: clang
+            compiler: clang++-15
+            cxxstd: "03,11,14,17,20,2b"
+            os: ubuntu-22.04
+            install:
+              - clang-15
+            sources:
+              - "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+            source_keys:
+              - "https://apt.llvm.org/llvm-snapshot.gpg.key"
+          - toolset: clang
+            compiler: clang++-15
+            cxxstd: "03,11,14,17,20,2b"
+            os: ubuntu-22.04
+            install:
+              - clang-15
+              - libc++-15-dev
+              - libc++abi-15-dev
+            sources:
+              - "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+            source_keys:
+              - "https://apt.llvm.org/llvm-snapshot.gpg.key"
+            cxxflags: -stdlib=libc++
+            linkflags: -stdlib=libc++
+          - name: UBSAN
+            toolset: clang
+            compiler: clang++-14
+            cxxstd: "03,11,14,17,20,2b"
+            cxxflags: -stdlib=libc++
+            linkflags: -stdlib=libc++
+            ubsan: 1
+            os: ubuntu-22.04
+            install:
+              - clang-14
+              - libc++-14-dev
+              - libc++abi-14-dev
+
+          - toolset: clang
+            cxxstd: "03,11,14,17,2a"
+            os: macos-11
+          - toolset: clang
+            cxxstd: "03,11,14,17,20,2b"
+            os: macos-12
+
+    timeout-minutes: 60
     runs-on: ${{matrix.os}}
+    container: ${{matrix.container}}
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Setup environment
+        run: |
+            if [ -f "/etc/debian_version" ]
+            then
+                echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+                export DEBIAN_FRONTEND=noninteractive
+            fi
+            if [ -n "${{matrix.container}}" ]
+            then
+                echo "GHA_CONTAINER=${{matrix.container}}" >> $GITHUB_ENV
+                if [ -f "/etc/debian_version" ]
+                then
+                    apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+                    if [ "$(apt-cache search "^python-is-python3$" | wc -l)" -ne 0 ]
+                    then
+                        PYTHON_PACKAGE="python-is-python3"
+                    else
+                        PYTHON_PACKAGE="python"
+                    fi
+                    apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common tzdata wget curl apt-transport-https ca-certificates make build-essential g++ $PYTHON_PACKAGE python3 perl git cmake
+                fi
+            fi
+            git config --global pack.threads 0
+      - uses: actions/checkout@v3
 
       - name: Install packages
         if: matrix.install
-        run: sudo apt install ${{matrix.install}}
-
+        run: |
+            declare -a SOURCE_KEYS SOURCES
+            if [ -n "${{join(matrix.source_keys, ' ')}}" ]
+            then
+                SOURCE_KEYS=("${{join(matrix.source_keys, '" "')}}")
+            fi
+            if [ -n "${{join(matrix.sources, ' ')}}" ]
+            then
+                SOURCES=("${{join(matrix.sources, '" "')}}")
+            fi
+            for key in "${SOURCE_KEYS[@]}"
+            do
+                for i in {1..$NET_RETRY_COUNT}
+                do
+                    echo "Adding key: $key"
+                    wget -O - "$key" | sudo apt-key add - && break || sleep 2
+                done
+            done
+            if [ ${#SOURCES[@]} -gt 0 ]
+            then
+                APT_ADD_REPO_COMMON_ARGS=("-y")
+                APT_ADD_REPO_SUPPORTED_ARGS="$(apt-add-repository --help | perl -ne 'if (/^\s*-n/) { print "n"; } elsif (/^\s*-P/) { print "P"; } elsif (/^\s*-S/) { print "S"; } elsif (/^\s*-U/) { print "U"; }')"
+                if [ -n "$APT_ADD_REPO_SUPPORTED_ARGS" -a -z "${APT_ADD_REPO_SUPPORTED_ARGS##*n*}" ]
+                then
+                    APT_ADD_REPO_COMMON_ARGS+=("-n")
+                fi
+                APT_ADD_REPO_HAS_SOURCE_ARGS="$([ -n "$APT_ADD_REPO_SUPPORTED_ARGS" -a -z "${APT_ADD_REPO_SUPPORTED_ARGS##*P*}" -a -z "${APT_ADD_REPO_SUPPORTED_ARGS##*S*}" -a -z "${APT_ADD_REPO_SUPPORTED_ARGS##*U*}" ] && echo 1 || echo 0)"
+                for source in "${SOURCES[@]}"
+                do
+                    for i in {1..$NET_RETRY_COUNT}
+                    do
+                        APT_ADD_REPO_ARGS=("${APT_ADD_REPO_COMMON_ARGS[@]}")
+                        if [ $APT_ADD_REPO_HAS_SOURCE_ARGS -ne 0 ]
+                        then
+                            case "$source" in
+                            "ppa:"*)
+                                APT_ADD_REPO_ARGS+=("-P")
+                                ;;
+                            "deb "*)
+                                APT_ADD_REPO_ARGS+=("-S")
+                                ;;
+                            *)
+                                APT_ADD_REPO_ARGS+=("-U")
+                                ;;
+                            esac
+                        fi
+                        APT_ADD_REPO_ARGS+=("$source")
+                        echo "apt-add-repository ${APT_ADD_REPO_ARGS[@]}"
+                        sudo -E apt-add-repository "${APT_ADD_REPO_ARGS[@]}" && break || sleep 2
+                    done
+                done
+            fi
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
+            sudo apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y ${{join(matrix.install, ' ')}}
+      - name: Setup GCC Toolchain
+        if: matrix.gcc_toolchain
+        run: |
+            GCC_TOOLCHAIN_ROOT="$HOME/gcc-toolchain"
+            echo "GCC_TOOLCHAIN_ROOT=\"$GCC_TOOLCHAIN_ROOT\"" >> $GITHUB_ENV
+            MULTIARCH_TRIPLET="$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+            mkdir -p "$GCC_TOOLCHAIN_ROOT"
+            ln -s /usr/include "$GCC_TOOLCHAIN_ROOT/include"
+            ln -s /usr/bin "$GCC_TOOLCHAIN_ROOT/bin"
+            mkdir -p "$GCC_TOOLCHAIN_ROOT/lib/gcc/$MULTIARCH_TRIPLET"
+            ln -s "/usr/lib/gcc/$MULTIARCH_TRIPLET/${{matrix.gcc_toolchain}}" "$GCC_TOOLCHAIN_ROOT/lib/gcc/$MULTIARCH_TRIPLET/${{matrix.gcc_toolchain}}"
       - name: Setup Boost
         run: |
-          REF=${GITHUB_BASE_REF:-$GITHUB_REF}
-          BOOST_BRANCH=develop && [ "$REF" == "master" ] && BOOST_BRANCH=master || true
-          cd ..
-          git clone -b $BOOST_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
-          cd boost-root
-          cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
-          git submodule update --init tools/boostdep
-          python tools/boostdep/depinst/depinst.py --git_args "--jobs 3" $LIBRARY
-          ./bootstrap.sh
-          ./b2 -d0 headers
-
+            echo GITHUB_REPOSITORY: $GITHUB_REPOSITORY
+            LIBRARY=${GITHUB_REPOSITORY#*/}
+            echo LIBRARY: $LIBRARY
+            echo "LIBRARY=$LIBRARY" >> $GITHUB_ENV
+            echo GITHUB_BASE_REF: $GITHUB_BASE_REF
+            echo GITHUB_REF: $GITHUB_REF
+            REF=${GITHUB_BASE_REF:-$GITHUB_REF}
+            REF=${REF#refs/heads/}
+            echo REF: $REF
+            BOOST_BRANCH=develop && [ "$REF" = "master" ] && BOOST_BRANCH=master || true
+            echo BOOST_BRANCH: $BOOST_BRANCH
+            BUILD_JOBS=$((nproc || sysctl -n hw.ncpu) 2> /dev/null)
+            echo "BUILD_JOBS=$BUILD_JOBS" >> $GITHUB_ENV
+            echo "CMAKE_BUILD_PARALLEL_LEVEL=$BUILD_JOBS" >> $GITHUB_ENV
+            DEPINST_ARGS=()
+            GIT_VERSION="$(git --version | sed -e 's/git version //')"
+            GIT_HAS_JOBS=1
+            if [ -f "/etc/debian_version" ]
+            then
+                if $(dpkg --compare-versions "$GIT_VERSION" lt 2.8.0)
+                then
+                    GIT_HAS_JOBS=0
+                fi
+            else
+                declare -a GIT_VER=(${GIT_VERSION//./ })
+                declare -a GIT_MIN_VER=(2 8 0)
+                for ((i=0; i<${#GIT_VER[@]}; i++))
+                do
+                    if [ -z "${GIT_MIN_VER[i]}" ]
+                    then
+                        GIT_MIN_VER[i]=0
+                    fi
+                    if [ "${GIT_VER[i]}" -lt "${GIT_MIN_VER[i]}" ]
+                    then
+                        GIT_HAS_JOBS=0
+                        break
+                    fi
+                done
+            fi
+            if [ "$GIT_HAS_JOBS" -ne 0 ]
+            then
+                DEPINST_ARGS+=("--git_args" "--jobs $GIT_FETCH_JOBS")
+            fi
+            cd ..
+            git clone -b "$BOOST_BRANCH" --depth 1 "https://github.com/boostorg/boost.git" "boost-root"
+            cd boost-root
+            mkdir -p libs/$LIBRARY
+            cp -r $GITHUB_WORKSPACE/* libs/$LIBRARY
+            git submodule update --init tools/boostdep
+            DEPINST_ARGS+=("$LIBRARY")
+            python tools/boostdep/depinst/depinst.py "${DEPINST_ARGS[@]}"
+            if [ -z "${{matrix.cmake_tests}}" ]
+            then
+                ./bootstrap.sh
+                ./b2 headers
+                if [ -n "${{matrix.compiler}}" -o -n "$GCC_TOOLCHAIN_ROOT" ]
+                then
+                    echo -n "using ${{matrix.toolset}} : : ${{matrix.compiler}}" > ~/user-config.jam
+                    if [ -n "$GCC_TOOLCHAIN_ROOT" ]
+                    then
+                        echo -n " : <compileflags>\"--gcc-toolchain=$GCC_TOOLCHAIN_ROOT\" <linkflags>\"--gcc-toolchain=$GCC_TOOLCHAIN_ROOT\"" >> ~/user-config.jam
+                    fi
+                    echo " ;" >> ~/user-config.jam
+                fi
+            fi
       - name: Run tests
+        if: matrix.cmake_tests == ''
         run: |
-          cd ../boost-root
-          ./b2 -j3 libs/$LIBRARY/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} variant=debug,release
+            cd ../boost-root
+            B2_ARGS=("-j" "$BUILD_JOBS" "toolset=${{matrix.toolset}}" "cxxstd=${{matrix.cxxstd}}" "link=static,shared")
+            if [ -n "${{matrix.build_variant}}" ]
+            then
+                B2_ARGS+=("variant=${{matrix.build_variant}}")
+            else
+                B2_ARGS+=("variant=$DEFAULT_BUILD_VARIANT")
+            fi
+            if [ -n "${{matrix.threading}}" ]
+            then
+                B2_ARGS+=("threading=${{matrix.threading}}")
+            fi
+            if [ -n "${{matrix.ubsan}}" ]
+            then
+                export UBSAN_OPTIONS="print_stacktrace=1"
+                B2_ARGS+=("cxxflags=-fsanitize=undefined -fno-sanitize-recover=undefined" "linkflags=-fsanitize=undefined -fuse-ld=gold" "define=UBSAN=1" "debug-symbols=on" "visibility=global")
+            fi
+            if [ -n "${{matrix.cxxflags}}" ]
+            then
+                B2_ARGS+=("cxxflags=${{matrix.cxxflags}}")
+            fi
+            if [ -n "${{matrix.linkflags}}" ]
+            then
+                B2_ARGS+=("linkflags=${{matrix.linkflags}}")
+            fi
+            if [ -n "${{matrix.address_model}}" ]
+            then
+                B2_ARGS+=("address-model=${{matrix.address_model}}")
+            fi
+            B2_ARGS+=("libs/$LIBRARY/test")
+            ./b2 "${B2_ARGS[@]}"

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -146,7 +146,7 @@ jobs:
               - g++-12-multilib
           - name: UBSAN
             toolset: gcc-12
-            cxxstd: "03,11,14,17,20,23"
+            cxxstd: "03,11,20"
             address_model: 64
             ubsan: 1
             os: ubuntu-22.04
@@ -282,7 +282,7 @@ jobs:
           - name: UBSAN
             toolset: clang
             compiler: clang++-14
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "03,11,20"
             cxxflags: -stdlib=libc++
             linkflags: -stdlib=libc++
             ubsan: 1

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -47,7 +47,7 @@ jobs:
             sources:
               - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.7
-            cxxstd: "03,11"
+            cxxstd: "03"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
@@ -56,7 +56,7 @@ jobs:
             sources:
               - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.8
-            cxxstd: "03,11"
+            cxxstd: "03"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -72,79 +72,79 @@ jobs:
               - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-5
             cxxstd: "03,11,14,1z"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
               - g++-5-multilib
           - toolset: gcc-5
             cxxstd: "03-gnu,11-gnu,14-gnu,1z-gnu"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
               - g++-5-multilib
           - toolset: gcc-6
             cxxstd: "03,11,14,1z"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - g++-6-multilib
           - toolset: gcc-7
             cxxstd: "03,11,14,17"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - g++-7-multilib
           - toolset: gcc-8
             cxxstd: "03,11,14,17,2a"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - g++-8-multilib
           - toolset: gcc-9
             cxxstd: "03,11,14,17,2a"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-20.04
             install:
               - g++-9-multilib
           - toolset: gcc-9
             cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,2a-gnu"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-20.04
             install:
               - g++-9-multilib
           - toolset: gcc-10
             cxxstd: "03,11,14,17,20"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-20.04
             install:
               - g++-10-multilib
           - toolset: gcc-11
             cxxstd: "03,11,14,17,20,23"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-22.04
             install:
               - g++-11-multilib
           - toolset: gcc-12
             cxxstd: "03,11,14,17,20,23"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-22.04
             install:
               - g++-12-multilib
           - toolset: gcc-12
             cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu,23-gnu"
-            address_model: 32,64
+            address_model: 64
             os: ubuntu-22.04
             install:
               - g++-12-multilib
           - name: UBSAN
             toolset: gcc-12
             cxxstd: "03,11,14,17,20,23"
-            address_model: 32,64
+            address_model: 64
             ubsan: 1
             os: ubuntu-22.04
             install:
@@ -296,7 +296,7 @@ jobs:
             cxxstd: "03,11,14,17,20,2b"
             os: macos-12
 
-    timeout-minutes: 60
+    timeout-minutes: 360
     runs-on: ${{matrix.os}}
     container: ${{matrix.container}}
 

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -52,7 +52,7 @@ jobs:
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
-              - g++-4.8
+              - g++-4.7
             sources:
               - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.8

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -279,18 +279,6 @@ jobs:
               - "https://apt.llvm.org/llvm-snapshot.gpg.key"
             cxxflags: -stdlib=libc++
             linkflags: -stdlib=libc++
-          - name: UBSAN
-            toolset: clang
-            compiler: clang++-14
-            cxxstd: "03,11,20"
-            cxxflags: -stdlib=libc++
-            linkflags: -stdlib=libc++
-            ubsan: 1
-            os: ubuntu-22.04
-            install:
-              - clang-14
-              - libc++-14-dev
-              - libc++abi-14-dev
 
           - toolset: clang
             cxxstd: "03,11,14,17,2a"

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -18,7 +18,7 @@ on:
       - feature/**
 
 concurrency:
-  group: ${{format('{0}:{1}', github.repository, github.ref)}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -30,6 +30,9 @@ env:
 
 jobs:
   CI:
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
           - toolset: msvc-14.0
             cxxstd: "11,14"
             addrmd: 32,64
-            ox: windows-2019
+            os: windows-2019
           - toolset: msvc-14.1
             cxxstd: "14,17,latest"
             addrmd: 32,64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - toolset: msvc-14.0
+            cxxstd: "11,14"
+            addrmd: 32,64
+            ox: windows-2019
           - toolset: msvc-14.1
             cxxstd: "14,17,latest"
             addrmd: 32,64
@@ -37,14 +41,21 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Boost
         shell: cmd
         run: |
+          echo GITHUB_REPOSITORY: %GITHUB_REPOSITORY%
+          for /f %%i in ("%GITHUB_REPOSITORY%") do set LIBRARY=%%~nxi
+          echo LIBRARY: %LIBRARY%
+          echo LIBRARY=%LIBRARY%>>%GITHUB_ENV%
+          echo GITHUB_BASE_REF: %GITHUB_BASE_REF%
+          echo GITHUB_REF: %GITHUB_REF%
           if "%GITHUB_BASE_REF%" == "" set GITHUB_BASE_REF=%GITHUB_REF%
           set BOOST_BRANCH=develop
-          if "%GITHUB_BASE_REF%" == "master" set BOOST_BRANCH=master
+          for /f %%i in ("%GITHUB_BASE_REF%") do if "%%~nxi" == "master" set BOOST_BRANCH=master
+          echo BOOST_BRANCH: %BOOST_BRANCH%
           cd ..
           git clone -b %BOOST_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
           cd boost-root

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,14 +25,18 @@ jobs:
             cxxstd: "11,14"
             addrmd: 32,64
             os: windows-2019
-          - toolset: msvc-14.1
-            cxxstd: "14,17,latest"
-            addrmd: 32,64
-            os: windows-2019
           - toolset: msvc-14.2
             cxxstd: "14,17,latest"
             addrmd: 32,64
             os: windows-2019
+          - toolset: msvc-14.3
+            cxxstd: "17,20,latest"
+            addrmd: 32,64
+            os: windows-2022
+          - toolset: clang-win
+            cxxstd: "14,17,latest"
+            addrmd: 32,64
+            os: windows-2022
           - toolset: gcc
             cxxstd: "03,11,14,17,2a"
             addrmd: 64

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,6 +8,10 @@ on:
       - develop
       - feature/**
 
+concurrency:
+  group: ${{format('{0}:{1}', github.repository, github.ref)}}
+  cancel-in-progress: true
+
 env:
   LIBRARY: serialization
 
@@ -20,7 +24,7 @@ jobs:
           - toolset: msvc-14.1
             cxxstd: "14,17,latest"
             addrmd: 32,64
-            os: windows-2016
+            os: windows-2019
           - toolset: msvc-14.2
             cxxstd: "14,17,latest"
             addrmd: 32,64
@@ -54,4 +58,4 @@ jobs:
         shell: cmd
         run: |
           cd ../boost-root
-          b2 -j3 libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} variant=debug,release
+          b2 -j3 libs/%LIBRARY%/test toolset=${{matrix.toolset}} cxxstd=${{matrix.cxxstd}} address-model=${{matrix.addrmd}} variant=release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,7 +9,7 @@ on:
       - feature/**
 
 concurrency:
-  group: ${{format('{0}:{1}', github.repository, github.ref)}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/include/boost/archive/detail/interface_oarchive.hpp
+++ b/include/boost/archive/detail/interface_oarchive.hpp
@@ -18,6 +18,7 @@
 #include <cstddef> // NULL
 #include <boost/cstdint.hpp>
 #include <boost/mpl/bool.hpp>
+#include <boost/detail/workaround.hpp>
 
 #include <boost/archive/detail/auto_link_archive.hpp>
 #include <boost/archive/detail/oserializer.hpp>
@@ -43,6 +44,13 @@ public:
     typedef mpl::bool_<true> is_saving;
 
     // return a pointer to the most derived class
+    #if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=40900)||\
+    BOOST_WORKAROUND(BOOST_CLANG,>=1)&&\
+    (__clang_major__>3 || __clang_major__==3 && __clang_minor__ >= 8)
+    /* https://github.com/boostorg/poly_collection/issues/15 */
+
+    __attribute__((no_sanitize("undefined")))
+    #endif
     Archive * This(){
         return static_cast<Archive *>(this);
     }

--- a/include/boost/archive/iterators/escape.hpp
+++ b/include/boost/archive/iterators/escape.hpp
@@ -82,7 +82,7 @@ class escape :
     }
 
    void increment(){
-        if(++m_bnext < m_bend){
+        if(m_bnext != NULL && ++m_bnext < m_bend){
             m_current_value = *m_bnext;
             return;
         }

--- a/include/boost/serialization/extended_type_info_no_rtti.hpp
+++ b/include/boost/serialization/extended_type_info_no_rtti.hpp
@@ -26,6 +26,8 @@
 #include <boost/type_traits/is_polymorphic.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
+#include <boost/detail/workaround.hpp>
+
 #include <boost/serialization/static_warning.hpp>
 #include <boost/serialization/singleton.hpp>
 #include <boost/serialization/extended_type_info.hpp>
@@ -98,6 +100,11 @@ class extended_type_info_no_rtti :
         }
     };
 public:
+    #if BOOST_WORKAROUND(BOOST_GCC_VERSION,>=40900)||\
+    BOOST_WORKAROUND(BOOST_CLANG,>=1)&&\
+    (__clang_major__>3 || __clang_major__==3 && __clang_minor__ >= 8)
+    __attribute__((no_sanitize("undefined")))
+    #endif
     extended_type_info_no_rtti() :
         no_rtti_system::extended_type_info_no_rtti_0(get_key())
     {


### PR DESCRIPTION
Github deprecated support for a number of old Ubuntu distributions so use containers and the Ubuntu toolchain PPA to keep support for older compilers.