### PR TITLE
Change BOOT_CLASS_EXPORT to BOOST_CLASS_EXPORT

### DIFF
--- a/doc/archive_reference.html
+++ b/doc/archive_reference.html
@@ -250,7 +250,7 @@ EXCEPT for one special case.
 <ul>
     <li>Instances of a derived class are serialized through a base class pointer.
     <li>Such instances are not "registered" neither implicitly nor explicitly. That
-    is, the macro <code style="white-space: normal">BOOT_CLASS_EXPORT</code> is used 
+    is, the macro <code style="white-space: normal">BOOST_CLASS_EXPORT</code> is used 
     to instantiate the serialization code for the included archives.
 </ul>
 


### PR DESCRIPTION
Fixing typo. 
Issue: https://github.com/boostorg/serialization/issues/222