### PR TITLE
Use the first instance of bos during serialization

### DIFF
--- a/src/basic_oarchive.cpp
+++ b/src/basic_oarchive.cpp
@@ -269,11 +269,11 @@ basic_oarchive_impl::save_object(
     }
 
     // we're not tracking this type of object
-    if(! bos.tracking(m_flags)){
+    if(! co.m_bos_ptr->tracking(m_flags)){
         // just windup the preamble - no object id to write
         ar.end_preamble();
         // and save the data
-        (bos.save_object_data)(ar, t);
+        (co.m_bos_ptr->save_object_data)(ar, t);
         return;
     }
 
@@ -291,7 +291,7 @@ basic_oarchive_impl::save_object(
         ar.vsave(oid);
         ar.end_preamble();
         // and data
-        (bos.save_object_data)(ar, t);
+        (co.m_bos_ptr->save_object_data)(ar, t);
         return;
     }
 
@@ -360,7 +360,7 @@ basic_oarchive_impl::save_pointer(
     }
 
     // if we're not tracking
-    if(! bos.tracking(m_flags)){
+    if(! co.m_bos_ptr->tracking(m_flags)){
         // just save the data itself
         ar.end_preamble();
         serialization::state_saver<const void *> x(pending_object);


### PR DESCRIPTION
There are situations when we can have multiple instances of basic_oserializer for the same type participating in serialization to the same archive. The issues start when these multiple instances have different object tracking settings, because in one executable you never serialize some type by pointer, and in another dll you serialized the type by pointer only once, and the second dll is now trying to store everything with object-tracking enabled. And if you serialized the same object into an archive twice but with both libraries you will not be able to correctly deserialize such an archive, you will end up seeing some random failure or "unregistered class exception", basically it is UB from this point.

The reading side in basic_iarchive.cpp always uses the first object tracking settings for a type it registers (in cobject_id_vector). So we should have the same logic in basic_oarchive.cpp.

Please check if this change is harmless, unfortunately it is not easy for me to extract reproducible example for this issue from our code, because it requires multiple modules.