### PR TITLE
XML ubsan fixes

### DIFF
--- a/include/boost/archive/detail/interface_oarchive.hpp
+++ b/include/boost/archive/detail/interface_oarchive.hpp
@@ -44,7 +44,7 @@ public:
 
     // return a pointer to the most derived class
     Archive * This(){
-        return static_cast<Archive *>(this);
+        return reinterpret_cast<Archive*>(this);
     }
 
     template<class T>

--- a/include/boost/archive/iterators/xml_escape.hpp
+++ b/include/boost/archive/iterators/xml_escape.hpp
@@ -76,6 +76,8 @@ char xml_escape<Base>::fill(
         bend = bstart + 6;
         break;
     default:
+        bstart="";
+        bend=bstart;
         return current_value;
     }
     return *bstart;


### PR DESCRIPTION
The XML oarchive class generates a few ubsan failures, this PR aims to fix them.

To replicate the failures on develop:
```bash
b2 -q test//test_mult_archive_types cxxstd=20 undefined-sanitizer=norecover address-sanitizer=norecover  link=static toolset=clang-16
```

The first failure is that we're incrementing a nullptr in the `increment()` of the `xml_escape` iterator because we never assigned `m_bnext` to non-null.

The second is a static_cast to a Base that we just replace with a reinterpret_cast, trying to utilize the common initial sequence to silence the sanitizer.

We found this in Unordered when adding Serialization support to some of our containers.