### PR TITLE
Fix predicate's defaulted copy constructor for C++03 while also fixing #276.

### DIFF
--- a/include/boost/archive/detail/helper_collection.hpp
+++ b/include/boost/archive/detail/helper_collection.hpp
@@ -55,7 +55,7 @@ class helper_collection
     collection m_collection;
 
     struct predicate {
-        // BOOST_DEFAULTED_FUNCTION(predicate(const predicate& rhs) : m_ti(rhs.m_ti), {})
+        BOOST_DEFAULTED_FUNCTION(predicate(const predicate& rhs), : m_ti(rhs.m_ti) {})
         BOOST_DELETED_FUNCTION(predicate & operator=(const predicate & rhs))
     public:
         const void * const m_ti;


### PR DESCRIPTION
Hi,

This fixes the issue I introduced in #276 (sorry for the breakage).

This time I tested not directly with boost, but using compiler explorer. This is the code I tested:

```
#include "boost/config.hpp"    

struct predicate {
    BOOST_DEFAULTED_FUNCTION(predicate(const predicate& rhs), : m_ti(rhs.m_ti) {})
    BOOST_DELETED_FUNCTION(predicate & operator=(const predicate & rhs))
public:
    const void * const m_ti;
    /*
    bool operator()(helper_value_type const &rhs) const {
        return m_ti == rhs.first;
    }
    */
    predicate(const void * ti) :
        m_ti(ti)
    {}  
};

void f(const predicate& a)
{
    predicate b(a);
    (void)b;
}
```

I tried with flags `-Wall -Wextra -Werror -std=gnu++03` and `-Wall -Wextra -Werror -std=gnu++23`, and with both gcc and clang x86_64 (trunk version in both cases). There is no compilation error in all these 4 different variants.

Compiler explorer link for clang/C++03: https://godbolt.org/z/PhPGsMdoM

Cheers,
Romain