### PR TITLE
Remove C++03 from GHA, because Variant and LexicalCast no longer compile under C++03

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -37,26 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - toolset: gcc-4.6
-            cxxstd: "03"
-            address_model: 64
-            os: ubuntu-latest
-            container: ubuntu:16.04
-            install:
-              - g++-4.6
-            sources:
-              - "ppa:ubuntu-toolchain-r/test"
-          - toolset: gcc-4.7
-            cxxstd: "03"
-            address_model: 64
-            os: ubuntu-latest
-            container: ubuntu:16.04
-            install:
-              - g++-4.7
-            sources:
-              - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.8
-            cxxstd: "03"
+            cxxstd: "11"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
@@ -65,7 +47,7 @@ jobs:
             sources:
               - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-4.9
-            cxxstd: "03,11"
+            cxxstd: "11"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
@@ -74,79 +56,79 @@ jobs:
             sources:
               - "ppa:ubuntu-toolchain-r/test"
           - toolset: gcc-5
-            cxxstd: "03,11,14,1z"
+            cxxstd: "11,14,1z"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
               - g++-5-multilib
           - toolset: gcc-5
-            cxxstd: "03-gnu,11-gnu,14-gnu,1z-gnu"
+            cxxstd: "11-gnu,14-gnu,1z-gnu"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
               - g++-5-multilib
           - toolset: gcc-6
-            cxxstd: "03,11,14,1z"
+            cxxstd: "11,14,1z"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - g++-6-multilib
           - toolset: gcc-7
-            cxxstd: "03,11,14,17"
+            cxxstd: "11,14,17"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - g++-7-multilib
           - toolset: gcc-8
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "11,14,17,2a"
             address_model: 64
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - g++-8-multilib
           - toolset: gcc-9
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "11,14,17,2a"
             address_model: 64
             os: ubuntu-20.04
             install:
               - g++-9-multilib
           - toolset: gcc-9
-            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,2a-gnu"
+            cxxstd: "11-gnu,14-gnu,17-gnu,2a-gnu"
             address_model: 64
             os: ubuntu-20.04
             install:
               - g++-9-multilib
           - toolset: gcc-10
-            cxxstd: "03,11,14,17,20"
+            cxxstd: "11,14,17,20"
             address_model: 64
             os: ubuntu-20.04
             install:
               - g++-10-multilib
           - toolset: gcc-11
-            cxxstd: "03,11,14,17,20,23"
+            cxxstd: "11,14,17,20,23"
             address_model: 64
             os: ubuntu-22.04
             install:
               - g++-11-multilib
           - toolset: gcc-12
-            cxxstd: "03,11,14,17,20,23"
+            cxxstd: "11,14,17,20,23"
             address_model: 64
             os: ubuntu-22.04
             install:
               - g++-12-multilib
           - toolset: gcc-12
-            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu,23-gnu"
+            cxxstd: "11-gnu,14-gnu,17-gnu,20-gnu,23-gnu"
             address_model: 64
             os: ubuntu-22.04
             install:
               - g++-12-multilib
           - name: UBSAN
             toolset: gcc-12
-            cxxstd: "03,11,20"
+            cxxstd: "11,20"
             address_model: 64
             ubsan: 1
             os: ubuntu-22.04
@@ -156,49 +138,49 @@ jobs:
           # Linux, clang
           - toolset: clang
             compiler: clang++-3.7
-            cxxstd: "03,11,14"
+            cxxstd: "11,14"
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
               - clang-3.7
           - toolset: clang
             compiler: clang++-3.8
-            cxxstd: "03,11,14"
+            cxxstd: "11,14"
             os: ubuntu-latest
             container: ubuntu:16.04
             install:
               - clang-3.8
           - toolset: clang
             compiler: clang++-3.9
-            cxxstd: "03,11,14"
+            cxxstd: "11,14"
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - clang-3.9
           - toolset: clang
             compiler: clang++-4.0
-            cxxstd: "03,11,14"
+            cxxstd: "11,14"
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - clang-4.0
           - toolset: clang
             compiler: clang++-5.0
-            cxxstd: "03,11,14,1z"
+            cxxstd: "11,14,1z"
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - clang-5.0
           - toolset: clang
             compiler: clang++-6.0
-            cxxstd: "03,11,14,17"
+            cxxstd: "11,14,17"
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
               - clang-6.0
           - toolset: clang
             compiler: clang++-7
-            cxxstd: "03,11,14,17"
+            cxxstd: "11,14,17"
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
@@ -206,7 +188,7 @@ jobs:
           # Note: clang-8 does not fully support C++20, so it is not compatible with libstdc++-8 in this mode
           - toolset: clang
             compiler: clang++-8
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "11,14,17,2a"
             os: ubuntu-latest
             container: ubuntu:18.04
             install:
@@ -215,49 +197,49 @@ jobs:
             gcc_toolchain: 7
           - toolset: clang
             compiler: clang++-9
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "11,14,17,2a"
             os: ubuntu-20.04
             install:
               - clang-9
           - toolset: clang
             compiler: clang++-10
-            cxxstd: "03,11,14,17,20"
+            cxxstd: "11,14,17,20"
             os: ubuntu-20.04
             install:
               - clang-10
           - toolset: clang
             compiler: clang++-11
-            cxxstd: "03,11,14,17,20"
+            cxxstd: "11,14,17,20"
             os: ubuntu-22.04
             install:
               - clang-11
           - toolset: clang
             compiler: clang++-12
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "11,14,17,20,2b"
             os: ubuntu-22.04
             install:
               - clang-12
           - toolset: clang
             compiler: clang++-13
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "11,14,17,20,2b"
             os: ubuntu-22.04
             install:
               - clang-13
           - toolset: clang
             compiler: clang++-14
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "11,14,17,20,2b"
             os: ubuntu-22.04
             install:
               - clang-14
           - toolset: clang
             compiler: clang++-14
-            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu,2b-gnu"
+            cxxstd: "11-gnu,14-gnu,17-gnu,20-gnu,2b-gnu"
             os: ubuntu-22.04
             install:
               - clang-14
           - toolset: clang
             compiler: clang++-15
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "11,14,17,20,2b"
             os: ubuntu-22.04
             install:
               - clang-15
@@ -267,7 +249,7 @@ jobs:
               - "https://apt.llvm.org/llvm-snapshot.gpg.key"
           - toolset: clang
             compiler: clang++-15
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "11,14,17,20,2b"
             os: ubuntu-22.04
             install:
               - clang-15
@@ -281,10 +263,10 @@ jobs:
             linkflags: -stdlib=libc++
 
           - toolset: clang
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "11,14,17,2a"
             os: macos-11
           - toolset: clang
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "11,14,17,20,2b"
             os: macos-12
 
     timeout-minutes: 360

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
             addrmd: 32,64
             os: windows-2022
           - toolset: gcc
-            cxxstd: "03,11,14,17,2a"
+            cxxstd: "11,14,17,2a"
             addrmd: 64
             os: windows-2019
 


### PR DESCRIPTION
This pull request removes the C++03 jobs from the Github Actions .yml files, because Boost.Variant and Boost.LexicalCast no longer compile under C++03, which makes all jobs fail.