### PR TITLE
Remove debug output from util/test.jam

### DIFF
--- a/util/test.jam
+++ b/util/test.jam
@@ -205,7 +205,7 @@ rule test-bsl-run_files ( test-name : sources * : libs * : requirements * ) {
 rule test-bsl-run_polymorphic_files ( test-name : sources * : libs * : requirements * ) {
     local tests ;
     for local defn in $(BOOST_ARCHIVE_LIST) {
-        ECHO polymorphic_$(defn:LB) ;
+        #ECHO polymorphic_$(defn:LB) ;
         tests += [ 
             test-bsl-run_archive $(test-name) 
             : polymorphic_$(defn:LB)


### PR DESCRIPTION
This comments out an `ECHO` statement in `util/test.jam`, which was probably used for debugging purposes. It results in the output
```
polymorphic_text_archive
polymorphic_text_warchive
polymorphic_binary_archive
polymorphic_xml_archive
polymorphic_xml_warchive
polymorphic_text_archive
polymorphic_text_warchive
polymorphic_binary_archive
polymorphic_xml_archive
polymorphic_xml_warchive
polymorphic_text_archive
polymorphic_text_warchive
polymorphic_binary_archive
polymorphic_xml_archive
polymorphic_xml_warchive
polymorphic_text_archive
polymorphic_text_warchive
polymorphic_binary_archive
polymorphic_xml_archive
polymorphic_xml_warchive
polymorphic_text_archive
polymorphic_text_warchive
polymorphic_binary_archive
polymorphic_xml_archive
polymorphic_xml_warchive
polymorphic_text_archive
polymorphic_text_warchive
polymorphic_binary_archive
polymorphic_xml_archive
polymorphic_xml_warchive
```
before
```
Performing configuration checks

    - default address-model    : 64-bit (cached) [1]
    - default architecture     : x86 (cached) [1]
    - symlinks supported       : yes (cached)
```
on each `b2` invocation, which is unnecessary.