### PR TITLE
Fix Sub::operator== signature to avoid ambiguity errors in C++20

### DIFF
--- a/test/test_multiple_inheritance.cpp
+++ b/test/test_multiple_inheritance.cpp
@@ -73,7 +73,7 @@ struct Sub :
         Base2(x),
         m_x(x)
     {}
-    bool operator==(Sub & rhs) const {
+    bool operator==(const Sub & rhs) const {
         if(! Base2::operator==(rhs))
             return false;
         if(! Base1::operator==(rhs))


### PR DESCRIPTION
`Sub::operator==` takes a non-const reference by mistake, which causes ambiguity errors under msvc-14.3 with cxxstd=20.