### PR TITLE
Fix clang-cl regression introduced by #282

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -107,7 +107,6 @@ WSOURCES =
     xml_woarchive
     polymorphic_xml_wiarchive
     polymorphic_xml_woarchive
-    $(SOURCES_HAS_STD_WSTREAMBUF)
 ;
 
 lib boost_serialization 


### PR DESCRIPTION
The sources conditioned on wstreambuf existence were mistakenly added to WSOURCES, which resulted in them being present in both libraries. This causes link errors with clang-cl.

This pull request removes the inadvertent addition, fixing the link errors.

Note that currently the clang-cl CI job still fails, but for reasons unrelated to this change and outside of our control (https://github.com/actions/runner-images/issues/8125.) It's supposed to be fixed by the GHA team this week when they deploy the fixed windows-2022 image.