### PR TITLE
Implement copy constructor

### DIFF
--- a/src/basic_xml_grammar.ipp
+++ b/src/basic_xml_grammar.ipp
@@ -82,7 +82,9 @@ struct assign_impl<std::string> {
             ++b;
         }
     }
-    //assign_impl(const assign_impl & rhs);
+    assign_impl(const assign_impl & rhs)
+        : m_t(rhs.m_t)
+    {}
     assign_impl & operator=(assign_impl & rhs);
     assign_impl(std::string & rhs)
         : m_t(rhs)


### PR DESCRIPTION
#280 take 2 (test matrix: toolset=clang-14,gcc-11 variant=debug,release cxxstd=11,14,17,20,2b)

The compiler-generated copy constructor is deprecated since C++11 on classes with user-declared copy assignment operator.

This change allows clean compilation with the -Wdeprecated-copy/-Wdeprecated-copy-with-user-provided-ctor flag.