### PR TITLE
Make BOOST_STRONG_TYPEDEF constexpr

### DIFF
--- a/include/boost/serialization/strong_typedef.hpp
+++ b/include/boost/serialization/strong_typedef.hpp
@@ -36,15 +36,15 @@ struct D                                                                        
     > >                                                                                                          \
 {                                                                                                                \
     T t;                                                                                                         \
-    explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {}          \
-    D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                             \
-    D(const D & t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                \
-    D& operator=(const D& rhs) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {t = rhs.t; return *this;} \
-    D& operator=(const T& rhs) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {t = rhs; return *this;}   \
-    operator const T&() const {return t;}                                                                        \
-    operator T&() {return t;}                                                                                    \
-    bool operator==(const D& rhs) const {return t == rhs.t;}                                                     \
-    bool operator<(const D& rhs) const {return t < rhs.t;}                                                       \
+    constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {}          \
+    constexpr D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                             \
+    constexpr D(const D & t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                \
+    constexpr D& operator=(const D& rhs) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {t = rhs.t; return *this;} \
+    constexpr D& operator=(const T& rhs) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {t = rhs; return *this;}   \
+    constexpr operator const T&() const {return t;}                                                                        \
+    constexpr operator T&() {return t;}                                                                                    \
+    constexpr bool operator==(const D& rhs) const {return t == rhs.t;}                                                     \
+    constexpr bool operator<(const D& rhs) const {return t < rhs.t;}                                                       \
 };
 
 #endif // BOOST_SERIALIZATION_STRONG_TYPEDEF_HPP


### PR DESCRIPTION
Lack of constexpr constructor for BOOST_STRONG_TYPEDEF  cause errors in clang and warning in gcc when using in constexpr functions.