### PR TITLE
fix "build/Jamfile.v2" - fix linking error when using wchar_t

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -107,6 +107,7 @@ WSOURCES =
     xml_woarchive
     polymorphic_xml_wiarchive
     polymorphic_xml_woarchive
+    codecvt_null
 ;
 
 lib boost_serialization 


### PR DESCRIPTION
I can provide the exact linker error and/or reproducible example, if necessary.

(This is a very old bug, present in boost-1.69 (and possibly before), I had to patch the boost for several years.)