### PR TITLE
Remove no longer necessary command line options from build/Jamfile, u…

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -118,12 +118,6 @@ lib boost_serialization
     <toolset>msvc:<cxxflags>/Gy
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
-    <toolset>clang:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"
-    <toolset>gcc:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"
-    <toolset>darwin:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"
-    <toolset>gcc:<cxxflags>"-ftemplate-depth-255"
-    <toolset>clang:<cxxflags>"-ftemplate-depth-255"
-    <toolset>darwin:<cxxflags>"-ftemplate-depth-255"
     <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
     ;
 
@@ -134,12 +128,6 @@ lib boost_wserialization
     <toolset>msvc:<cxxflags>/Gy 
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
-    <toolset>clang:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"
-    <toolset>gcc:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"
-    <toolset>darwin:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"
-    <toolset>gcc:<cxxflags>"-ftemplate-depth-255"
-    <toolset>clang:<cxxflags>"-ftemplate-depth-255"
-    <toolset>darwin:<cxxflags>"-ftemplate-depth-255"
     # note: both serialization and wserialization are conditioned on the this
     # switch - don't change it to BOOST_WSERIALIZATION_DYN_LINK
     <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1

--- a/util/test.jam
+++ b/util/test.jam
@@ -52,9 +52,6 @@ rule run-template ( test-name : sources * : files * : requirements * ) {
             <toolset>msvc:<cxxflags>"-wd4996"
             <toolset>clang:<variant>debug:<cxxflags>"-fsanitize=memory"
             # toolset optimizations
-            <toolset>gcc:<cxxflags>"-ftemplate-depth-255"
-            <toolset>clang:<cxxflags>"-ftemplate-depth-255"
-            <toolset>darwin:<cxxflags>"-ftemplate-depth-255"
             <toolset>msvc:<cxxflags>"-Gy"
             # linking
             <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 


### PR DESCRIPTION
…til/test.jam

`-fvisibility=hidden`, `-fvisibility-inlines-hidden` are now supplied automatically by b2, because the default for the `visibility` feature when building Boost is `hidden`.

`-ftemplate-depth-255` (itself an obsolete spelling for `-ftemplate-depth=255`) is no longer necessary, because the default as of C++11 is 1024 (so 255 actually decreases it).

In addition, none of these options are supported by Clang for Windows (clang-cl), so removing them avoids warnings when building with it.