### PR TITLE
Fixed include logic when BOOST_NO_EXCEPTIONS is defined

### DIFF
--- a/include/boost/serialization/throw_exception.hpp
+++ b/include/boost/serialization/throw_exception.hpp
@@ -17,7 +17,7 @@
 
 #include <boost/config.hpp>
 
-#ifndef BOOST_NO_EXCEPTIONS
+#ifdef BOOST_NO_EXCEPTIONS
 #include <boost/throw_exception.hpp>
 #endif
 


### PR DESCRIPTION
In response to issue https://github.com/boostorg/serialization/issues/315
