### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,28 +7,28 @@ import project ;
 
 project /boost/serialization
     : common-requirements
-        <source>/boost/array//boost_array
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/function//boost_function
-        <source>/boost/integer//boost_integer
-        <source>/boost/io//boost_io
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/move//boost_move
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/optional//boost_optional
-        <source>/boost/predef//boost_predef
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/spirit//boost_spirit
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/unordered//boost_unordered
-        <source>/boost/utility//boost_utility
-        <source>/boost/variant//boost_variant
+        <library>/boost/array//boost_array
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/function//boost_function
+        <library>/boost/integer//boost_integer
+        <library>/boost/io//boost_io
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/move//boost_move
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/optional//boost_optional
+        <library>/boost/predef//boost_predef
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/spirit//boost_spirit
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/unordered//boost_unordered
+        <library>/boost/utility//boost_utility
+        <library>/boost/variant//boost_variant
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -19,6 +19,7 @@ project /boost/serialization
         <library>/boost/io//boost_io
         <library>/boost/iterator//boost_iterator
         <library>/boost/move//boost_move
+        <library>/boost/mp11//boost_mp11
         <library>/boost/mpl//boost_mpl
         <library>/boost/optional//boost_optional
         <library>/boost/predef//boost_predef
@@ -28,9 +29,9 @@ project /boost/serialization
         <library>/boost/static_assert//boost_static_assert
         <library>/boost/throw_exception//boost_throw_exception
         <library>/boost/type_traits//boost_type_traits
-        <library>/boost/unordered//boost_unordered
         <library>/boost/utility//boost_utility
         <library>/boost/variant//boost_variant
+        <library>/boost/variant2//boost_variant2
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -11,7 +11,6 @@ constant boost_dependencies :
     /boost/config//boost_config
     /boost/core//boost_core
     /boost/detail//boost_detail
-    /boost/function//boost_function
     /boost/integer//boost_integer
     /boost/io//boost_io
     /boost/iterator//boost_iterator

--- a/build.jam
+++ b/build.jam
@@ -5,31 +5,33 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/array//boost_array
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/function//boost_function
+    /boost/integer//boost_integer
+    /boost/io//boost_io
+    /boost/iterator//boost_iterator
+    /boost/move//boost_move
+    /boost/mp11//boost_mp11
+    /boost/mpl//boost_mpl
+    /boost/optional//boost_optional
+    /boost/predef//boost_predef
+    /boost/preprocessor//boost_preprocessor
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/spirit//boost_spirit
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility
+    /boost/variant//boost_variant
+    /boost/variant2//boost_variant2 ;
+
 project /boost/serialization
     : common-requirements
-        <library>/boost/array//boost_array
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/function//boost_function
-        <library>/boost/integer//boost_integer
-        <library>/boost/io//boost_io
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/move//boost_move
-        <library>/boost/mp11//boost_mp11
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/optional//boost_optional
-        <library>/boost/predef//boost_predef
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/spirit//boost_spirit
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
-        <library>/boost/variant//boost_variant
-        <library>/boost/variant2//boost_variant2
         <include>include
     ;
 
@@ -42,3 +44,4 @@ explicit
 call-if : boost-library serialization
     : install boost_serialization boost_wserialization
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/serialization

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,43 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/serialization
+    : common-requirements
+        <source>/boost/array//boost_array
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/function//boost_function
+        <source>/boost/integer//boost_integer
+        <source>/boost/io//boost_io
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/move//boost_move
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/optional//boost_optional
+        <source>/boost/predef//boost_predef
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/spirit//boost_spirit
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/unordered//boost_unordered
+        <source>/boost/utility//boost_utility
+        <source>/boost/variant//boost_variant
+        <include>include
+    ;
+
+explicit
+    [ alias boost_serialization : build//boost_serialization ]
+    [ alias boost_wserialization : build//boost_wserialization ]
+    [ alias all : boost_serialization boost_wserialization example test ]
+    ;
+
+call-if : boost-library serialization
+    : install boost_serialization boost_wserialization
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/serialization
     : common-requirements

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -1,7 +1,7 @@
 # Boost serialization Library Build Jamfile
 #  (C) Copyright Robert Ramey 2002-2004.
-#  Use, modification, and distribution are subject to the 
-#  Boost Software License, Version 1.0. (See accompanying file 
+#  Use, modification, and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 #  See http://www.boost.org/libs/serialization for the library home page.
@@ -22,41 +22,41 @@ rule include-spirit ( properties * )
     local old-compiler ;
     if <toolset>borland in $(properties)
     {
-        if ! <toolset-borland:version>6.1.0 in $(properties)  
-        {  
-            old-compiler = true ;  
-        }  
+        if ! <toolset-borland:version>6.1.0 in $(properties)
+        {
+            old-compiler = true ;
+        }
 
     }
     else if <toolset>msvc in $(properties)
     {
         if <toolset-msvc:version>6.5 in $(properties)
           || <toolset-msvc:version>7.0 in $(properties)
-        {            
+        {
             old-compiler = true ;
-        }        
+        }
     }
-        
+
     local result ;
     if $(old-compiler)
-    {        
+    {
         if $(SPIRIT_ROOT)
         {
-            # note - we can't use <include>$(SPIRIT_ROOT) because 
+            # note - we can't use <include>$(SPIRIT_ROOT) because
             # it puts -I$(SPIRIT_ROOT) AFTER the "../../.." in the command line.
-            # so use these instead 
+            # so use these instead
             result = <cxxflags>-I$(SPIRIT_ROOT) ;
         }
-        else 
+        else
         {
             echo **** spirit 1.6x required to build library with this compiler **** ;
             result = <build>no ;
         }
-    }    
+    }
     return $(result) ;
 }
 
-SOURCES = 
+SOURCES =
     archive_exception
     basic_archive
     basic_iarchive
@@ -92,12 +92,12 @@ SOURCES =
     codecvt_null
  ;
 
-SOURCES_HAS_STD_WSTREAMBUF = 
+SOURCES_HAS_STD_WSTREAMBUF =
     xml_oarchive
     utf8_codecvt_facet
 ;
 
-WSOURCES = 
+WSOURCES =
     basic_text_wiprimitive
     basic_text_woprimitive
     text_wiarchive
@@ -112,11 +112,11 @@ WSOURCES =
     codecvt_null
 ;
 
-lib boost_serialization 
+lib boost_serialization
     : ## sources ##
      $(SOURCES).cpp
     : ## requirements ##
-    [ check-target-builds ../../config/checks//std_wstreambuf : <source>../src/$(SOURCES_HAS_STD_WSTREAMBUF).cpp ]
+    [ check-target-builds /boost/config/checks//std_wstreambuf : <source>../src/$(SOURCES_HAS_STD_WSTREAMBUF).cpp ]
     <toolset>msvc:<cxxflags>/Gy
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
@@ -129,11 +129,11 @@ lib boost_serialization
     <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
     ;
 
-lib boost_wserialization 
-    : $(WSOURCES).cpp boost_serialization 
-    : 
+lib boost_wserialization
+    : $(WSOURCES).cpp boost_serialization
+    :
     [ requires std_wstreambuf ]
-    <toolset>msvc:<cxxflags>/Gy 
+    <toolset>msvc:<cxxflags>/Gy
     <toolset>msvc:<define>_SCL_SECURE_NO_WARNINGS
     <toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
     <toolset>clang:<cxxflags>"-fvisibility=hidden -fvisibility-inlines-hidden"

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -12,6 +12,7 @@ import config : requires ;
 
 project
     : source-location ../src
+    : common-requirements <library>$(boost_dependencies)
     : requirements
       <conditional>@include-spirit
     : usage-requirements

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -10,11 +10,16 @@ require-b2 5.0.1 ;
 import-search /boost/config/checks ;
 import config : requires ;
 
+constant boost_dependencies_private :
+    /boost/function//boost_function
+    ;
+
 project
     : source-location ../src
     : common-requirements <library>$(boost_dependencies)
     : requirements
       <conditional>@include-spirit
+      <library>$(boost_dependencies_private)
     : usage-requirements
         <define>BOOST_SERIALIZATION_NO_LIB=1
 ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -6,13 +6,15 @@
 #
 #  See http://www.boost.org/libs/serialization for the library home page.
 
-project boost/serialization
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
+
+project
     : source-location ../src
     : requirements
       <conditional>@include-spirit
 ;
-
-import ../../config/checks/config : requires ;
 
 SPIRIT_ROOT = [ modules.peek : SPIRIT_ROOT ] ;
 rule include-spirit ( properties * )
@@ -144,5 +146,3 @@ lib boost_wserialization
     # switch - don't change it to BOOST_WSERIALIZATION_DYN_LINK
     <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
     ;
-
-boost-install boost_serialization boost_wserialization ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -14,6 +14,8 @@ project
     : source-location ../src
     : requirements
       <conditional>@include-spirit
+    : usage-requirements
+        <define>BOOST_SERIALIZATION_NO_LIB=1
 ;
 
 SPIRIT_ROOT = [ modules.peek : SPIRIT_ROOT ] ;

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -19,7 +19,6 @@ import ../util/test :
     test-bsl-run
     test-bsl-run_archive
     test-bsl-run_files
-    test-bsl-run_polymorphic_archive
 ;
 
 test-suite "demo-suite" :

--- a/performance/Jamfile.v2
+++ b/performance/Jamfile.v2
@@ -21,7 +21,6 @@ import ../util/test :
     test-bsl-run
     test-bsl-run_archive
     test-bsl-run_files
-    test-bsl-run_polymorphic_archive
 ;
 
 BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;
@@ -33,7 +32,6 @@ test-suite "performance" :
 #    [ test-bsl-run_files performance_vector ]
 #    [ test-bsl-run_files performance_no_rtti ]
 #    [ test-bsl-run_files performance_simple_class ]
-#    [ test-bsl-run_polymorphic_archive performance_polymorphic : ../test/test_polymorphic_A ]
     
     [ test-bsl-run-no-lib performance_iterators ]
     [ test-bsl-run-no-lib performance_iterators_base64 ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,7 +9,7 @@
 project
     : id serialization_test
     : requirements <library>/boost/filesystem//boost_filesystem
-        <library>/boost/math//boost_math
+        <library>/boost/math//boost_math_tr1
     ;
 
 # import rules for testing conditional on config file variables

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,8 +1,8 @@
 # Boost serialization Library test Jamfile
 
 #  (C) Copyright Robert Ramey 2002-2004.
-#  Use, modification, and distribution are subject to the 
-#  Boost Software License, Version 1.0. (See accompanying file 
+#  Use, modification, and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
@@ -13,6 +13,7 @@ project
     ;
 
 # import rules for testing conditional on config file variables
+import-search /boost/config/checks ;
 import config : requires ;
 
 # import rules from the boost serialization test
@@ -28,9 +29,9 @@ import ../util/test :
 ;
 
 BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;
-    
+
 lib dll_a
-    : 
+    :
         dll_a.cpp
         ../build//boost_serialization
     :
@@ -39,7 +40,7 @@ lib dll_a
 
 lib dll_polymorphic_base
     :
-        dll_polymorphic_base.cpp 
+        dll_polymorphic_base.cpp
         ../build//boost_serialization
     :
         <link>shared
@@ -131,7 +132,7 @@ test-suite "serialization" :
     ;
 
 if ! $(BOOST_ARCHIVE_LIST) {
-    test-suite "serialization2" : 
+    test-suite "serialization2" :
         [ test-bsl-run test_inclusion ]
         [ test-bsl-run test_inclusion2 ]
 
@@ -179,7 +180,7 @@ if ! $(BOOST_ARCHIVE_LIST) {
         #[ compile test_const_save_warn1_nvp.cpp ]
         #[ compile test_const_save_warn2_nvp.cpp ]
         #[ compile test_const_save_warn3_nvp.cpp ]
-        
+
         # should compile
         [ compile test_traits_pass.cpp ]
         [ compile test_const_pass.cpp ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,13 +6,14 @@
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
-project libs/serialization/test
+project
     : id serialization_test
-    : requirements <library>/boost/filesystem
+    : requirements <library>/boost/filesystem//boost_filesystem
+        <library>/boost/math//boost_math
     ;
 
 # import rules for testing conditional on config file variables
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 # import rules from the boost serialization test
 import ../util/test :

--- a/util/test.jam
+++ b/util/test.jam
@@ -11,7 +11,6 @@
 # tests.
 
 # import rules for testing conditional on config file variables
-import-search /boost/config/checks ;
 import config : requires ;
 
 BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;

--- a/util/test.jam
+++ b/util/test.jam
@@ -11,7 +11,7 @@
 # tests.
 
 # import rules for testing conditional on config file variables
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;
 

--- a/util/test.jam
+++ b/util/test.jam
@@ -1,8 +1,8 @@
 # Boost serialization Library utility test Jamfile
 
 #  (C) Copyright Robert Ramey 2002-2004.
-#  Use, modification, and distribution are subject to the 
-#  Boost Software License, Version 1.0. (See accompanying file 
+#  Use, modification, and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
@@ -11,6 +11,7 @@
 # tests.
 
 # import rules for testing conditional on config file variables
+import-search /boost/config/checks ;
 import config : requires ;
 
 BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;
@@ -18,12 +19,12 @@ BOOST_ARCHIVE_LIST = [ modules.peek : BOOST_ARCHIVE_LIST ] ;
 # these are used to shorten testing while in development.  It permits
 # testing to be applied to just a particular type of archive
 if ! $(BOOST_ARCHIVE_LIST) {
-    BOOST_ARCHIVE_LIST = 
-        "text_archive.hpp" 
-        "text_warchive.hpp" 
-        "binary_archive.hpp" 
-        "xml_archive.hpp" 
-        "xml_warchive.hpp" 
+    BOOST_ARCHIVE_LIST =
+        "text_archive.hpp"
+        "text_warchive.hpp"
+        "binary_archive.hpp"
+        "xml_archive.hpp"
+        "xml_warchive.hpp"
     ;
     # enable the tests which don't depend on a particular archive
     BOOST_SERIALIZATION_TEST = true ;
@@ -57,8 +58,8 @@ rule run-template ( test-name : sources * : files * : requirements * ) {
             <toolset>darwin:<cxxflags>"-ftemplate-depth-255"
             <toolset>msvc:<cxxflags>"-Gy"
             # linking
-            <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1 
-            <link>shared:<define>BOOST_WSERIALIZATION_DYN_LINK=1 
+            <link>shared:<define>BOOST_SERIALIZATION_DYN_LINK=1
+            <link>shared:<define>BOOST_WSERIALIZATION_DYN_LINK=1
             $(requirements)
         : # test name
             $(test-name)
@@ -73,7 +74,7 @@ rule dependency-save-test ( test )
     if $(m)
     {
         return $(m[1])save$(m[2]) ;
-    }  
+    }
 }
 
 # each of the following tests is run with each type of archive
@@ -82,7 +83,7 @@ rule run-invoke ( test-name : sources * : files * : requirements * )
     local save-test = [ dependency-save-test $(test-name) ] ;
 
     local tests ;
-    tests += [ 
+    tests += [
         run-template $(test-name)
         : # sources
             $(sources)
@@ -102,7 +103,7 @@ rule run-winvoke ( test-name : sources * : files * : requirements * )
     local save-test = [ dependency-save-test $(test-name) ] ;
 
     local tests ;
-    tests += [ 
+    tests += [
         run-template $(test-name)
         : # sources
             $(sources)
@@ -124,7 +125,7 @@ rule run-winvoke ( test-name : sources * : files * : requirements * )
 rule test-bsl-run-no-lib  ( test-name : sources * : requirements * )
 {
     local tests ;
-    tests += [ 
+    tests += [
         run-template $(test-name)
         : # sources
             $(test-name).cpp $(sources).cpp
@@ -139,8 +140,8 @@ rule test-bsl-run-no-lib  ( test-name : sources * : requirements * )
 rule test-bsl-run ( test-name : sources * : libs * : requirements * )
 {
     local tests ;
-    tests +=  [ 
-        run-invoke $(test-name) 
+    tests +=  [
+        run-invoke $(test-name)
         : # sources
             $(test-name).cpp $(sources).cpp $(libs)
         : # input files
@@ -191,27 +192,27 @@ rule test-bsl-run_archive ( test-name : archive-name : sources * : libs * : requ
 rule test-bsl-run_files ( test-name : sources * : libs * : requirements * ) {
     local tests ;
     for local defn in $(BOOST_ARCHIVE_LIST) {
-        tests += [ 
-            test-bsl-run_archive $(test-name) 
-            : $(defn:LB) 
-            : $(test-name) $(sources) 
-            : $(libs) 
-            : $(requirements) 
+        tests += [
+            test-bsl-run_archive $(test-name)
+            : $(defn:LB)
+            : $(test-name) $(sources)
+            : $(libs)
+            : $(requirements)
         ] ;
     }
     return $(tests) ;
 }
-    
+
 rule test-bsl-run_polymorphic_files ( test-name : sources * : libs * : requirements * ) {
     local tests ;
     for local defn in $(BOOST_ARCHIVE_LIST) {
         #ECHO polymorphic_$(defn:LB) ;
-        tests += [ 
-            test-bsl-run_archive $(test-name) 
+        tests += [
+            test-bsl-run_archive $(test-name)
             : polymorphic_$(defn:LB)
-            : $(test-name) $(sources) 
-            : $(libs) 
-            : $(requirements) 
+            : $(test-name) $(sources)
+            : $(libs)
+            : $(requirements)
         ] ;
     }
     return $(tests) ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.