### PR TITLE
Add a diagnostic hint to input stream error

### DIFF
--- a/include/boost/archive/basic_text_iprimitive.hpp
+++ b/include/boost/archive/basic_text_iprimitive.hpp
@@ -26,6 +26,7 @@
 
 #include <locale>
 #include <cstddef> // size_t
+#include <cstdlib> // itoa
 
 #include <boost/config.hpp>
 #if defined(BOOST_NO_STDC_NAMESPACE)
@@ -86,10 +87,13 @@ protected:
     template<class T>
     void load(T & t)
     {
+        auto pos = is.tellg();
         if(is >> t)
             return;
+        static char at_offset[64] = "at offset ";
+        itoa(pos, &at_offset[10], 10);
         boost::serialization::throw_exception(
-            archive_exception(archive_exception::input_stream_error)
+            archive_exception(archive_exception::input_stream_error, at_offset)
         );
     }
 

--- a/include/boost/archive/basic_text_iprimitive.hpp
+++ b/include/boost/archive/basic_text_iprimitive.hpp
@@ -26,7 +26,7 @@
 
 #include <locale>
 #include <cstddef> // size_t
-#include <cstdlib> // itoa
+#include <stdio.h> // snprintf
 
 #include <boost/config.hpp>
 #if defined(BOOST_NO_STDC_NAMESPACE)
@@ -90,11 +90,14 @@ protected:
         auto pos = is.tellg();
         if(is >> t)
             return;
-        static char at_offset[64] = "at offset ";
-        itoa(pos, &at_offset[10], 10);
+        char at_offset[64] = "at offset ";
+        if (std::streampos(-1) == pos)
+            snprintf&at_offset[10], 54, "%s", "<unknown>");
+        else
+            snprintf(&at_offset[10], 54, "%d", static_cast<std::streamoff>(pos));
         boost::serialization::throw_exception(
             archive_exception(archive_exception::input_stream_error, at_offset)
-        );
+            );
     }
 
     void load(char & t)

--- a/include/boost/archive/basic_text_iprimitive.hpp
+++ b/include/boost/archive/basic_text_iprimitive.hpp
@@ -92,9 +92,9 @@ protected:
             return;
         char at_offset[64] = "at offset ";
         if (std::streampos(-1) == pos)
-            snprintf&at_offset[10], 54, "%s", "<unknown>");
+            snprintf(&at_offset[10], 54, "%s", "<unknown>");
         else
-            snprintf(&at_offset[10], 54, "%d", static_cast<std::streamoff>(pos));
+            snprintf(&at_offset[10], 54, "%lld", static_cast<std::streamoff>(pos));
         boost::serialization::throw_exception(
             archive_exception(archive_exception::input_stream_error, at_offset)
             );


### PR DESCRIPTION
This PR aims to save users some time when diagnosing an input_stream_error.

For example, a NaN value serialized as `<PlanningCost>-nan(ind)</PlanningCost>` results in an input_stream_error exception when the file is reloaded.
