### PR TITLE
Move t instead of copying the value

### DIFF
--- a/include/boost/serialization/optional.hpp
+++ b/include/boost/serialization/optional.hpp
@@ -83,7 +83,7 @@ void load_impl(
     }
     typename OT::value_type t;
     ar >> boost::serialization::make_nvp("value",t);
-    ot = t;
+    ot = std::move(t);
 }
 
 } // detail


### PR DESCRIPTION
`std::optional<T>` does not compile when T has a move operator and the copy operator is deleted.