### PR TITLE
fix CVE-2023-34399

### DIFF
--- a/src/basic_iarchive.cpp
+++ b/src/basic_iarchive.cpp
@@ -427,7 +427,7 @@ basic_iarchive_impl::load_pointer(
     class_id_type cid;
     load(ar, cid);
 
-    if(BOOST_SERIALIZATION_NULL_POINTER_TAG == cid){
+    if(/* BOOST_SERIALIZATION_NULL_POINTER_TAG */ cid < 0){
         t = NULL;
         return bpis_ptr;
     }


### PR DESCRIPTION
Negative indexing bug. Left the null tag commented for posterity/search purposes.

Reference: https://securelist.com/mercedes-benz-head-unit-security-research/115218/