### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ target_link_libraries(boost_serialization
     Boost::preprocessor
     Boost::smart_ptr
     Boost::spirit
-    Boost::static_assert
     Boost::type_traits
     Boost::unordered
     Boost::utility

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,6 @@ install:
   - git submodule init libs/range
   - git submodule init libs/smart_ptr
   - git submodule init libs/spirit
-  - git submodule init libs/static_assert
   - git submodule init libs/system
   - git submodule init libs/throw_exception
   - git submodule init libs/tuple

--- a/build.jam
+++ b/build.jam
@@ -22,7 +22,6 @@ constant boost_dependencies :
     /boost/preprocessor//boost_preprocessor
     /boost/smart_ptr//boost_smart_ptr
     /boost/spirit//boost_spirit
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits
     /boost/utility//boost_utility


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.