### PR TITLE
Don't let the XML input archive destructor throw at end of input

### DIFF
--- a/include/boost/archive/impl/xml_iarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_iarchive_impl.ipp
@@ -189,7 +189,14 @@ xml_iarchive_impl<Archive>::~xml_iarchive_impl(){
     if(boost::core::uncaught_exceptions() > 0)
         return;
     if(0 == (this->get_flags() & no_header)){
-        gimpl->windup(is);
+        // windup() parses the trailing end tag; an exception must not escape
+        // this (implicitly noexcept) destructor and terminate the process.
+        // A stream error while consuming the trailer is not worth that.  #99
+        BOOST_TRY {
+            gimpl->windup(is);
+        }
+        BOOST_CATCH(...) {}
+        BOOST_CATCH_END
     }
 }
 } // namespace archive

--- a/include/boost/archive/impl/xml_wiarchive_impl.ipp
+++ b/include/boost/archive/impl/xml_wiarchive_impl.ipp
@@ -177,7 +177,14 @@ xml_wiarchive_impl<Archive>::~xml_wiarchive_impl(){
     if(boost::core::uncaught_exceptions() > 0)
         return;
     if(0 == (this->get_flags() & no_header)){
-        gimpl->windup(is);
+        // windup() parses the trailing end tag; an exception must not escape
+        // this (implicitly noexcept) destructor and terminate the process.
+        // A stream error while consuming the trailer is not worth that.  #99
+        BOOST_TRY {
+            gimpl->windup(is);
+        }
+        BOOST_CATCH(...) {}
+        BOOST_CATCH_END
     }
 }
 

--- a/src/basic_xml_grammar.ipp
+++ b/src/basic_xml_grammar.ipp
@@ -191,6 +191,15 @@ bool basic_xml_grammar<CharType>::my_parse(
     for(;;){
         CharType result;
         is.get(result);
+        // Reaching end of input while scanning for the next character is the
+        // normal way an archive ends (e.g. windup() consuming the trailer);
+        // it is not a stream error.  get() sets both eofbit and failbit at end
+        // of stream, so test eof() *before* fail() -- otherwise the normal
+        // termination is misreported as input_stream_error, which is fatal
+        // when it surfaces in the (noexcept) archive destructor via windup().
+        // See #99.
+        if(is.eof())
+            return false;
         if(is.fail()){
             boost::serialization::throw_exception(
                 boost::archive::archive_exception(
@@ -199,8 +208,6 @@ bool basic_xml_grammar<CharType>::my_parse(
                 )
             );
         }
-        if(is.eof())
-            return false;
         arg += result;
         if(result == delimiter)
             break;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -152,6 +152,7 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_reset_object_address : A ]
         [ test-bsl-run test_void_cast ]
         [ test-bsl-run test_xml_trailing_whitespace ]
+        [ test-bsl-run test_xml_missing_nvp ]
         [ test-bsl-run test_mult_archive_types : : : [ requires std_wstreambuf ] ]
         [ test-bsl-run test_iterators : : : [ requires std_wstreambuf ] ]
         [ test-bsl-run test_iterators_base64 ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -151,6 +151,7 @@ if ! $(BOOST_ARCHIVE_LIST) {
         [ test-bsl-run test_private_ctor ]
         [ test-bsl-run test_reset_object_address : A ]
         [ test-bsl-run test_void_cast ]
+        [ test-bsl-run test_xml_trailing_whitespace ]
         [ test-bsl-run test_mult_archive_types : : : [ requires std_wstreambuf ] ]
         [ test-bsl-run test_iterators : : : [ requires std_wstreambuf ] ]
         [ test-bsl-run test_iterators_base64 ]

--- a/test/test_xml_missing_nvp.cpp
+++ b/test/test_xml_missing_nvp.cpp
@@ -1,0 +1,58 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_xml_missing_nvp.cpp
+
+// Copyright 2026 Gennaro Prota
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// https://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for issue #109.  Attempting to read an nvp that is not
+// present throws archive_exception, which the caller may catch.  The failed
+// read consumes the closing tag, so at destruction windup() reaches end of
+// input -- the same Boost 1.66 my_parse regression as #82/#99, reached by a
+// different path.  The input archive must still destruct without terminating.
+
+#include <sstream>
+#include <string>
+
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/archive_exception.hpp>
+#include <boost/serialization/nvp.hpp>
+
+#include "test_tools.hpp"
+
+int test_main(int /* argc */, char * /* argv */ []){
+    // Build a valid XML archive holding a single value.
+    std::string content;
+    {
+        std::ostringstream os;
+        {
+            boost::archive::xml_oarchive oa(os);
+            const int x = 42;
+            oa << boost::serialization::make_nvp("x", x);
+        }
+        content = os.str();
+    }
+
+    int x = 0;
+    bool caught = false;
+    {
+        std::istringstream is(content);
+        boost::archive::xml_iarchive ia(is);
+        ia >> boost::serialization::make_nvp("x", x);
+        try {
+            int y = 0;
+            ia >> boost::serialization::make_nvp("not_there", y);
+        } catch (const boost::archive::archive_exception &){
+            caught = true;
+        }
+        // `ia` is destroyed here, after the caught exception.  Before the fix,
+        // windup() hit end of input (the failed read consumed the closing
+        // tag) and threw out of the noexcept destructor, terminating.
+    }
+    BOOST_CHECK(42 == x);
+    BOOST_CHECK(caught);
+
+    return EXIT_SUCCESS;
+}

--- a/test/test_xml_trailing_whitespace.cpp
+++ b/test/test_xml_trailing_whitespace.cpp
@@ -1,0 +1,59 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_xml_trailing_whitespace.cpp
+
+// Copyright 2026 Gennaro Prota
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// https://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for issue #99.  When an XML input archive is destroyed and
+// its stream has no closing tag left -- only trailing whitespace before end
+// of input (a truncated archive; the reported case had the stream "contain
+// \r\n") -- windup() reaches end of input while scanning for the trailing
+// tag.  End of input there is normal termination, not a stream error, so the
+// (implicitly noexcept) destructor must complete cleanly rather than throw,
+// which used to terminate the process.
+
+#include <sstream>
+#include <string>
+
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/serialization/nvp.hpp>
+
+#include "test_tools.hpp"
+
+int test_main(int /* argc */, char * /* argv */ []){
+    // Build a valid XML archive holding a single value.
+    std::string content;
+    {
+        std::ostringstream os;
+        {
+            boost::archive::xml_oarchive oa(os);
+            const int x = 42;
+            oa << boost::serialization::make_nvp("x", x);
+        }
+        content = os.str();
+    }
+
+    // Drop the closing document tag and leave only trailing whitespace, so the
+    // input archive's windup() reaches end of input at destruction instead of
+    // finding a tag.
+    const std::string::size_type close = content.rfind("</boost_serialization>");
+    BOOST_REQUIRE(std::string::npos != close);
+    content.erase(close);
+    content += "\r\n";
+
+    int y = 0;
+    {
+        std::istringstream is(content);
+        boost::archive::xml_iarchive ia(is);
+        ia >> boost::serialization::make_nvp("x", y);
+        // `ia` is destroyed here with only trailing whitespace left.  Before
+        // the fix, windup() threw input_stream_error out of the noexcept
+        // destructor and terminated the process.
+    }
+    BOOST_CHECK(42 == y);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
An XML input archive whose stream reaches end of input during `windup()` (run from the destructor) no longer throws, which, from an implicitly `noexcept` destructor, was calling `std::terminate`/`abort`.

## Root cause

`windup()` calls `my_parse()`. Boost 1.66 (commit `64dc620`, whose real purpose was dropping a `<codecvt>` dependency) changed `my_parse()` from returning `false` on a stream `fail()` to throwing `input_stream_error`:

```cpp
is.get(result);
if(is.fail())
    return false;      // <= 1.65
// vs
if(is.fail())
    throw ...;         // 1.66+
```

`get()` sets **both** `failbit` and `eofbit` at end of input, and the check tested `fail()` before `eof()`. So simply reaching the end while scanning for a tag threw; and since that happens inside the destructor's `windup()`, the exception escaped the `noexcept` destructor and terminated the process.

The close tag can be absent at that point for several reasons, which is why this surfaced as three separate reports:

- A **truncated** stream: #99.
- An archive whose writer was **never flushed** (so the close tag was never written): #82.
- A **well-formed** archive whose close tag an **earlier failed read already consumed** (e.g. probing for an nvp that isn't there) : #109.

## Issues

Fixes #99 (same root cause as the already-closed #82).

It also removes the process-terminating crash reported in #109, but **not** that issue's broader "broken state after an exception": a failed read still consumes input and leaves the archive unusable, which is a separate, by-design limitation of the forward-only positional parse (you can't probe for an absent named element without consuming input). So this only refs #109 rather than closing it; we can later decide whether #109 should be closed as "crash fixed, remainder by design" or kept open.