### PR TITLE
Record the first-registered serializer's tracking flag on save

### DIFF
--- a/src/basic_oarchive.cpp
+++ b/src/basic_oarchive.cpp
@@ -255,7 +255,7 @@ basic_oarchive_impl::save_object(
     if(bos.class_info()){
         if( ! co.m_initialized){
             ar.vsave(class_id_optional_type(co.m_class_id));
-            ar.vsave(tracking_type(bos.tracking(m_flags)));
+            ar.vsave(tracking_type(co.m_bos_ptr->tracking(m_flags)));
             ar.vsave(version_type(bos.version()));
             (const_cast<cobject_type &>(co)).m_initialized = true;
         }
@@ -343,7 +343,7 @@ basic_oarchive_impl::save_pointer(
             }
         }
         if(bos.class_info()){
-            ar.vsave(tracking_type(bos.tracking(m_flags)));
+            ar.vsave(tracking_type(co.m_bos_ptr->tracking(m_flags)));
             ar.vsave(version_type(bos.version()));
         }
         (const_cast<cobject_type &>(co)).m_initialized = true;


### PR DESCRIPTION
Since 1.85, a Derived object serialized through a Base pointer across module boundaries loses its data on load: the base subobject reads back empty. PR #287 changed save to decide whether to emit an object id from `co.m_bos_ptr` (the first serializer instance registered for a type), but left the tracking flag written into the class preamble taken from `bos`, the instance the current call happens to use.

Those can differ. With `track_selectively`, two module-local serializer singletons for one type report different `tracking()`: the one whose pointer serializer has been registered has `serialized_as_pointer()` true, the other false. The writer then records one flag but lays the object out per the other, so the reader desyncs and the subobject is misread.

Record `co.m_bos_ptr`'s flag, the same instance the id decision uses, so save is self-consistent again, as it was before PR #287 when both sides read `bos`. The output is byte-identical whenever `co.m_bos_ptr == &bos` (every single-module archive); only the already-broken cross-module case changes.

Fixes issue #329.