### PR TITLE
Give collection_size_type explicit increment, decrement, and stream extractor

### DIFF
--- a/include/boost/serialization/collection_size_type.hpp
+++ b/include/boost/serialization/collection_size_type.hpp
@@ -2,11 +2,13 @@
 #define BOOST_SERIALIZATION_COLLECTION_SIZE_TYPE_HPP
 
 // (C) Copyright 2005 Matthias Troyer
+// Copyright 2026 Gennaro Prota
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <cstddef> // size_t
+#include <istream>
 #include <boost/serialization/strong_typedef.hpp>
 #include <boost/serialization/level.hpp>
 #include <boost/serialization/split_free.hpp>
@@ -41,9 +43,23 @@ public:
     operator base_type () const {
         return t;
     }
-    // used for text input
-    operator base_type & () {
-        return t;
+    collection_size_type & operator++(){
+        ++t;
+        return *this;
+    }
+    collection_size_type operator++(int){
+        collection_size_type old(*this);
+        ++t;
+        return old;
+    }
+    collection_size_type & operator--(){
+        --t;
+        return *this;
+    }
+    collection_size_type operator--(int){
+        collection_size_type old(*this);
+        --t;
+        return old;
     }
     bool operator==(const collection_size_type & rhs) const {
         return t == rhs.t;
@@ -53,6 +69,14 @@ public:
     }
 };
 
+template<class Ch, class Tr>
+std::basic_istream<Ch, Tr> &
+operator>>(std::basic_istream<Ch, Tr> & is, collection_size_type & t){
+    std::size_t x = 0;
+    is >> x;
+    t = collection_size_type(x);
+    return is;
+}
 
 } } // end namespace boost::serialization
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -66,6 +66,7 @@ test-suite "serialization" :
      [ test-bsl-run_files test_class_info_load ]
      [ test-bsl-run_files test_class_template_version ]
      [ test-bsl-run_files test_bitset ]
+     [ test-bsl-run_files test_collection_size_type ]
      [ test-bsl-run_files test_complex ]
      [ test-bsl-run_files test_contained_class : A ]
      [ test-bsl-run_files test_cyclic_ptrs : A ]

--- a/test/test_collection_size_type.cpp
+++ b/test/test_collection_size_type.cpp
@@ -1,0 +1,74 @@
+/////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
+// test_collection_size_type.cpp
+
+// Copyright 2026 Gennaro Prota
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// https://www.boost.org/LICENSE_1_0.txt)
+
+// Exercises the interface of collection_size_type.  See also
+// issue #192.
+
+#include <cstddef>
+#include <cstdio>
+#include <fstream>
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_NO_STDC_NAMESPACE)
+namespace std{
+    using ::remove;
+}
+#endif
+
+#include <boost/serialization/collection_size_type.hpp>
+#include <boost/serialization/nvp.hpp>
+#include "test_tools.hpp"
+
+int test_main(int /* argc */, char * /* argv */[]){
+    using boost::serialization::collection_size_type;
+
+    collection_size_type c(5);
+    BOOST_CHECK(static_cast<std::size_t>(c) == 5);
+    BOOST_CHECK(c == collection_size_type(5));
+    BOOST_CHECK(collection_size_type(4) < c);
+
+    ++c;
+    BOOST_CHECK(static_cast<std::size_t>(c) == 6);
+    --c;
+    BOOST_CHECK(static_cast<std::size_t>(c) == 5);
+
+    const collection_size_type post_inc = c++;
+    BOOST_CHECK(static_cast<std::size_t>(post_inc) == 5);
+    BOOST_CHECK(static_cast<std::size_t>(c) == 6);
+    const collection_size_type post_dec = c--;
+    BOOST_CHECK(static_cast<std::size_t>(post_dec) == 6);
+    BOOST_CHECK(static_cast<std::size_t>(c) == 5);
+
+    collection_size_type count(3);
+    std::size_t iterations = 0;
+    while(count-- > 0){
+        ++iterations;
+    }
+    BOOST_CHECK(iterations == 3);
+
+    // round trip through an archive
+    const char * testfile = boost::archive::tmpnam(NULL);
+    BOOST_REQUIRE(NULL != testfile);
+    const collection_size_type saved(1234);
+    {
+        test_ostream os(testfile, TEST_STREAM_FLAGS);
+        test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
+        oa << boost::serialization::make_nvp("count", saved);
+    }
+    collection_size_type loaded(0);
+    {
+        test_istream is(testfile, TEST_STREAM_FLAGS);
+        test_iarchive ia(is, TEST_ARCHIVE_FLAGS);
+        ia >> boost::serialization::make_nvp("count", loaded);
+    }
+    BOOST_CHECK(static_cast<std::size_t>(loaded) == 1234);
+
+    std::remove(testfile);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
`collection_size_type` had no increment, decrement, or stream extractor but had an implicit conversion to a modifiable reference to its stored size (`operator base_type &`) which allowed the built-in operators to apply.

Remove that mutable-reference conversion and provide the operations the library actually needs explicitly: pre/post `++` and `--`, and an `operator>>` for input (templated on the character type, so it serves narrow and wide text and XML archives). The read-only `operator base_type() const` is kept: output, container sizing, and comparisons go through it, so no call sites change.

The on-disk format is unchanged. Binary archives already serialize the type bitwise; text and XML still read and write the same size through `is >> x` / `os << x`.

Adds test_collection_size_type, which checks the operators directly and round-trips a value through every archive type.

Closes #192.