### PR TITLE
Include <cwchar> unconditionally in wchar_from_mb

### DIFF
--- a/include/boost/archive/iterators/wchar_from_mb.hpp
+++ b/include/boost/archive/iterators/wchar_from_mb.hpp
@@ -18,9 +18,7 @@
 
 #include <cctype>
 #include <cstddef> // size_t
-#ifndef BOOST_NO_CWCHAR
 #include <cwchar>  // mbstate_t
-#endif
 #include <algorithm> // copy
 
 #include <boost/config.hpp>


### PR DESCRIPTION
The iterator uses `std::mbstate_t` and `std::mbsinit` directly, yet the include of `<cwchar>` was guarded by `BOOST_NO_CWCHAR`. That guard was misleading: when `BOOST_NO_CWCHAR` was defined the header was skipped but the code below still used those symbols, so the file could not compile in that configuration anyway. Therefore, include the header unconditionally.

Closes #196.