### PR TITLE
Track variant selectively so reused values round-trip

### DIFF
--- a/include/boost/serialization/variant.hpp
+++ b/include/boost/serialization/variant.hpp
@@ -294,7 +294,7 @@ struct tracking_level<
     variant<BOOST_VARIANT_ENUM_PARAMS(T)>
 >{
     typedef mpl::integral_c_tag tag;
-    typedef mpl::int_< ::boost::serialization::track_always> type;
+    typedef mpl::int_< ::boost::serialization::track_selectively> type;
     BOOST_STATIC_CONSTANT(int, value = type::value);
 };
 
@@ -304,7 +304,7 @@ struct tracking_level<
     std::variant<Types...>
 >{
     typedef mpl::integral_c_tag tag;
-    typedef mpl::int_< ::boost::serialization::track_always> type;
+    typedef mpl::int_< ::boost::serialization::track_selectively> type;
     BOOST_STATIC_CONSTANT(int, value = type::value);
 };
 #endif

--- a/test/test_variant.cpp
+++ b/test/test_variant.cpp
@@ -194,6 +194,32 @@ void test(Variant & v)
     test_type(v);
 }
 
+// Serializing the same variant twice by value must store two independent
+// values, not an object reference the loader cannot resolve into a separate
+// destination object. Regression test for issue #203.
+template<class Variant>
+void test_reuse(const Variant & v){
+    const char * testfile = boost::archive::tmpnam(NULL);
+    BOOST_REQUIRE(testfile != NULL);
+    {
+        test_ostream os(testfile, TEST_STREAM_FLAGS);
+        test_oarchive oa(os, TEST_ARCHIVE_FLAGS);
+        oa << boost::serialization::make_nvp("first", v);
+        oa << boost::serialization::make_nvp("second", v);
+    }
+    Variant v1;
+    Variant v2;
+    {
+        test_istream is(testfile, TEST_STREAM_FLAGS);
+        test_iarchive ia(is, TEST_ARCHIVE_FLAGS);
+        ia >> boost::serialization::make_nvp("first", v1);
+        ia >> boost::serialization::make_nvp("second", v2);
+    }
+    BOOST_CHECK(are_equal(v, v1));
+    BOOST_CHECK(are_equal(v, v2));
+    std::remove(testfile);
+}
+
 int test_boost_variant(){
     std::cerr << "Testing boost_variant\n";
     boost::variant<bool, int, float, double, A, std::string> v;
@@ -201,6 +227,8 @@ int test_boost_variant(){
     const A a;
     boost::variant<bool, int, float, double, const A *, std::string> v1 = & a;
     test_type(v1);
+    v = 1;
+    test_reuse(v);
     return EXIT_SUCCESS;
 }
 
@@ -214,6 +242,8 @@ int test_boost_variant2(){
     const A a;
     boost::variant2::variant<bool, int, float, double, const A *, std::string> v1 = & a;
     test_type(v1);
+    v = 1;
+    test_reuse(v);
     return EXIT_SUCCESS;
 }
 #endif
@@ -228,6 +258,8 @@ int test_std_variant(){
     const A a;
     std::variant<bool, int, float, double, const A *, std::string> v1 = & a;
     test_type(v1);
+    v = 1;
+    test_reuse(v);
     return EXIT_SUCCESS;
 }
 #endif


### PR DESCRIPTION
`boost::variant` and `std::variant` specialized `tracking_level` to `track_always`. With object tracking on, serializing the same variant twice by value wrote the second occurrence as a bare object reference. On load, that reference could not be resolved into a separate destination: value loads receive their destination by value, not by reference, so the tracking table has nowhere to copy from, and the second variant silently loaded as empty.

So, use `track_selectively` (the default for class types) for all three variant flavors: a variant is tracked when serialized through a pointer and stored by value otherwise, matching every other value type. The tracking flag is written per object in the class info, so archives written with the old track_always variant still load correctly and no archive version bump is needed.

Also add a regression test that serializes a variant twice into one archive and checks that both copies load back to the original value.

Closes #203.