### PR TITLE
Use BOOST_WARCHIVE_DECL for codecvt_null<wchar_t> members

### DIFF
--- a/include/boost/archive/codecvt_null.hpp
+++ b/include/boost/archive/codecvt_null.hpp
@@ -66,7 +66,7 @@ template<>
 class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> :
     public std::codecvt<wchar_t, char, std::mbstate_t>
 {
-    BOOST_SYMBOL_EXPORT std::codecvt_base::result
+    BOOST_WARCHIVE_DECL std::codecvt_base::result
     do_out(
         std::mbstate_t & state,
         const wchar_t * first1,
@@ -77,7 +77,7 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> :
         char * & next2
     ) const BOOST_OVERRIDE;
 
-    BOOST_SYMBOL_EXPORT std::codecvt_base::result
+    BOOST_WARCHIVE_DECL std::codecvt_base::result
     do_in(
         std::mbstate_t & state,
         const char * first1,
@@ -88,21 +88,21 @@ class BOOST_SYMBOL_VISIBLE codecvt_null<wchar_t> :
         wchar_t * & next2
     ) const BOOST_OVERRIDE;
 
-    BOOST_SYMBOL_EXPORT int do_encoding( ) const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {
+    int do_encoding( ) const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {
         return sizeof(wchar_t) / sizeof(char);
     }
 
-    BOOST_SYMBOL_EXPORT bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {
+    bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {
         return false;
     }
 
-    BOOST_SYMBOL_EXPORT int do_max_length( ) const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {
+    int do_max_length( ) const BOOST_NOEXCEPT_OR_NOTHROW BOOST_OVERRIDE {
         return do_encoding();
     }
 public:
-    BOOST_SYMBOL_EXPORT explicit codecvt_null(std::size_t no_locale_manage = 0);
+    BOOST_WARCHIVE_DECL explicit codecvt_null(std::size_t no_locale_manage = 0);
 
-    BOOST_SYMBOL_EXPORT ~codecvt_null() BOOST_OVERRIDE ;
+    BOOST_WARCHIVE_DECL ~codecvt_null() BOOST_OVERRIDE ;
 };
 
 } // namespace archive

--- a/src/codecvt_null.cpp
+++ b/src/codecvt_null.cpp
@@ -18,7 +18,7 @@
 namespace boost {
 namespace archive {
 
-BOOST_SYMBOL_EXPORT std::codecvt_base::result
+BOOST_WARCHIVE_DECL std::codecvt_base::result
 codecvt_null<wchar_t>::do_out(
     std::mbstate_t & /*state*/,
     const wchar_t * first1, 
@@ -46,7 +46,7 @@ codecvt_null<wchar_t>::do_out(
     return std::codecvt_base::ok;
 }
 
-BOOST_SYMBOL_EXPORT std::codecvt_base::result
+BOOST_WARCHIVE_DECL std::codecvt_base::result
 codecvt_null<wchar_t>::do_in(
     std::mbstate_t & /*state*/,
     const char * first1, 
@@ -80,11 +80,11 @@ codecvt_null<wchar_t>::do_in(
     return std::codecvt_base::ok;
 }
 
-BOOST_SYMBOL_EXPORT codecvt_null<wchar_t>::codecvt_null(std::size_t no_locale_manage) :
+BOOST_WARCHIVE_DECL codecvt_null<wchar_t>::codecvt_null(std::size_t no_locale_manage) :
     std::codecvt<wchar_t, char, std::mbstate_t>(no_locale_manage)
 {}
 
-BOOST_SYMBOL_EXPORT codecvt_null<wchar_t>::~codecvt_null()
+BOOST_WARCHIVE_DECL codecvt_null<wchar_t>::~codecvt_null()
 {}
 
 } // namespace archive


### PR DESCRIPTION
The members were declared `BOOST_SYMBOL_EXPORT` (always `dllexport`), so every consumer re-exported them even under static linking, and a DLL and EXE both using a wide archive yielded a LNK2005 error from MSVC. Use `BOOST_WARCHIVE_DECL` (and nothing on inline functions), instead, as the other archive classes do.

Fixes #232.