### PR TITLE
Let filter_iterator honour an end iterator

### DIFF
--- a/include/boost/archive/iterators/remove_whitespace.hpp
+++ b/include/boost/archive/iterators/remove_whitespace.hpp
@@ -100,6 +100,13 @@ class filter_iterator
     typedef filter_iterator<Predicate, Base> this_t;
     typedef typename super_t::reference reference_type;
 
+    void satisfy_predicate(){
+        while(this->base_reference() != m_end
+        && ! m_predicate(* this->base_reference())){
+            ++(this->base_reference());
+        }
+    }
+
     reference_type dereference_impl(){
         if(! m_full){
             while(! m_predicate(* this->base_reference()))
@@ -110,23 +117,47 @@ class filter_iterator
     }
 
     reference_type dereference() const {
+        if(m_bounded){
+            return * this->base_reference();
+        }
         return const_cast<this_t *>(this)->dereference_impl();
     }
 
     Predicate m_predicate;
     bool m_full;
+    Base m_end;
+    bool m_bounded;
 public:
     // note: this function is public only because comeau compiler complained
     // I don't know if this is because the compiler is wrong or what
     void increment(){
-        m_full = false;
         ++(this->base_reference());
+        if(m_bounded){
+            satisfy_predicate();
+        }
+        else{
+            m_full = false;
+        }
     }
     filter_iterator(Base start) :
         super_t(start),
-        m_full(false)
+        m_full(false),
+        m_end(),
+        m_bounded(false)
     {}
-    filter_iterator(){}
+    filter_iterator(Base start, Base end) :
+        super_t(start),
+        m_full(false),
+        m_end(end),
+        m_bounded(true)
+    {
+        satisfy_predicate();
+    }
+    filter_iterator() :
+        m_full(false),
+        m_end(),
+        m_bounded(false)
+    {}
 };
 
 template<class Base>
@@ -153,6 +184,10 @@ public:
     template<class T>
     remove_whitespace(T start) :
         super_t(Base(static_cast< T >(start)))
+    {}
+    template<class T>
+    remove_whitespace(T start, T end) :
+        super_t(Base(static_cast< T >(start)), Base(static_cast< T >(end)))
     {}
 };
 

--- a/test/test_iterators.cpp
+++ b/test/test_iterators.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib> // for rand
 #include <functional>
 #include <sstream> // used to test stream iterators
+#include <string>
 #include <clocale>
 #include <iterator> // begin
 #include <locale> // setlocale
@@ -32,6 +33,7 @@ namespace std{
 #endif
 #include <boost/archive/iterators/xml_escape.hpp>
 #include <boost/archive/iterators/xml_unescape.hpp>
+#include <boost/archive/iterators/remove_whitespace.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/archive/iterators/istream_iterator.hpp>
 #include <boost/archive/iterators/ostream_iterator.hpp>
@@ -195,6 +197,23 @@ void test_stream_iterators(
     BOOST_CHECK(std::equal(test_data, test_data + size,isi));
 }
 
+// Regression test for issue #254: the bounded (two-argument) filter form
+// must handle a range that ends in a non-matching element without running
+// past the end.
+void test_remove_whitespace(){
+    typedef boost::archive::iterators::remove_whitespace<const char *> translator;
+
+    const char with_ws[] = "  a b\tc \n"; // leading, embedded and trailing ws
+    const char * b = with_ws;
+    const char * e = with_ws + sizeof(with_ws) / sizeof(char) - 1;
+    BOOST_CHECK(std::string(translator(b, e), translator(e, e)) == "abc");
+
+    const char all_ws[] = "   ";          // filters to empty, must not overrun
+    const char * wb = all_ws;
+    const char * we = all_ws + sizeof(all_ws) / sizeof(char) - 1;
+    BOOST_CHECK(std::string(translator(wb, we), translator(we, we)).empty());
+}
+
 int
 test_main(int /* argc */, char* /* argv */ [] )
 {
@@ -252,6 +271,8 @@ test_main(int /* argc */, char* /* argv */ [] )
     test_transform_width<6, 8>(6);
     test_transform_width<6, 8>(7);
     test_transform_width<6, 8>(8);
+
+    test_remove_whitespace();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
`remove_whitespace` and its `filter_iterator` base read past the end of the input on a range that ends in a filtered-out element, e.g. trailing whitespace (#254). Given an end, they now stop at it. The unbounded form is kept for the base64 pipeline, which has no end.

Fixes #254.